### PR TITLE
Improve README and contributor documentation

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,17 +1,15 @@
-So you want to contribute to Lumol and create the next generation of
-molecular simulation engine? Great! This document tries to explain how you can
-contribute, but in case of doubt do not hesitate to contact me at
-luthaf@luthaf.fr.
+So you want to contribute to Lumol and create the next generation of molecular
+simulation engine? Great! This document explains how you can contribute, but in
+case of doubt do not hesitate to contact us in [the chat room][Gitter]
 
 # Bug reports and feature requests
 
-Bug and feature requests should be reported as [Github
-issue](https://github.com/lumol-org/lumol/issues/new). For bugs, you should
-provide information so that we can reproduce it: what did you try? What did you
-expect? What happened instead? Please provide any useful code snippet or input file
-with your bug report.
+Bug and feature requests should be reported as [Github issue][issues]. For bugs,
+you should provide information so that we can reproduce it: what did you try?
+What did you expect? What happened instead? Please provide any useful code
+snippet or input file with your bug report.
 
-# Area of contribution
+# Contributing
 
 A lot of contributions can be made to Lumol, and most of them do not involve
 writing code:
@@ -22,13 +20,71 @@ writing code:
 - Adding new potentials;
 - Adding new simulation algorithm;
 
-All these contributions are very welcome. I accept contributions either via
-Github pull request (have a look
-[here](https://help.github.com/articles/using-pull-requests/) for Github model
-of pull request); or you can send me patches by email at luthaf@luthaf.fr.
+All these contributions are very welcome. We accept contributions either via
+Github pull request (have a look [here][PR] for Github model of pull request);
+or you can send patches by email at luthaf@luthaf.fr.
 
-If you want to work on the code and pick something easy to get started, have a look at the
-[Level:Easy](https://github.com/lumol-org/lumol/labels/L%3AEasy) issues.
+If you want to work on the code and pick something easy to get started, have a
+look at the [easy level issues][L-Easy].
 
 If you want to add a new feature to Lumol, please create an issue so that we
 can discuss it, and you have more chances to see your changes incorporated.
+
+## Contribution check-list
+
+Every item in this list is explained in the next section
+
+- [ ] Fork Lumol;
+- [ ] Create a local branch;
+- [ ] Add code / correct typos / ...;
+    - [ ] Add new tests with your code;
+    - [ ] Add documentation for your code;
+- [ ] Check that the tests still pass;
+- [ ] Push to Github;
+- [ ] Create a Pull-Request;
+- [ ] Celebrate! :tada: :cake: :tada:
+
+## Contribution tutorial
+
+In this small tutorial, you should replace `<angle brackets>` as needed. If
+anything is unclear, please [ask][Gitter] for clarifications! There are no dumb
+questions.
+
+---
+
+Start by [forking Lumol][fork], and then clone and build your fork locally by
+running:
+
+```bash
+git clone https://github.com/<YOUR USERNAME>/lumol
+cd lumol
+cargo build
+```
+
+Then create a new branch for your changes
+
+```bash
+git checkout -b <new-branch>
+```
+
+Do your changes, containing the documentation and associated unit tests for new
+code.
+
+Then, run all the test and check that they still pass:
+
+```bash
+# Unit tests
+cd src/core && cargo test && cd ../..
+cd src/input && cargo test && cd ../..
+# Simulation tests, in relase mode to be faster
+cargo test --release
+```
+
+Finally, you can push your code to Github, and create a [Pull-Request][PR] to
+the `lumol-org/lumol` repository.
+
+[Gitter]: https://gitter.im/lumol-org/lumol
+[issues]: https://github.com/lumol-org/lumol/issues/new
+[PR]: https://help.github.com/articles/using-pull-requests/
+[L-Easy]: https://github.com/lumol-org/lumol/labels/L%3AEasy
+[fork]: https://help.github.com/articles/fork-a-repo/

--- a/README.md
+++ b/README.md
@@ -1,52 +1,59 @@
-# Lumol: extensible molecular simulation engine
+# Lumol molecular simulation engine
 
 [![Build Status](https://travis-ci.org/lumol-org/lumol.svg?branch=master)](https://travis-ci.org/lumol-org/lumol)
 [![Coverage](https://codecov.io/gh/lumol-org/lumol/branch/master/graph/badge.svg)](https://codecov.io/gh/lumol-org/lumol)
 [![Documentation](https://img.shields.io/badge/documentation-latest-brightgreen.svg)](https://lumol-org.github.io/lumol/latest/index.html)
 [![Gitter](https://badges.gitter.im/lumol-org/lumol.svg)](https://gitter.im/lumol-org/lumol)
 
-Lumol is a classical molecular simulation engine that provides a solid
-base for developing new algorithms and methods.
+Lumol is a classical molecular simulation engine that provides a solid base for
+developing new algorithms and methods. Using Lumol, you can customize the
+behavior of all the algorithms in a simulation. Adding a new force field,
+customizing Monte-Carlo moves or molecular dynamics integrators is easy and well
+documented.
 
-Using Lumol, you can customize the behavior of all the algorithms in a
-simulation (from force fields to barostats and Monte-Carlo moves). Lumol is
+Lumol goals are to be flexible, reliable and extensible. For us, this means that
+this software should be:
 
-- **Easy to extend**: the code is modular, object-oriented, well documented,
-  open-source and readable;
-- **Easy to use**: the user interface is nice, with human-oriented input files.
-- **Stable**: it will never crash on a good input, and tries to provide helpful
-  error messages.
+- **flexible**: the code can simulate all kind of systems, from proteins to
+  crystals, using various methods: molecular dynamics, Monte-Carlo, *etc.*
+- **reliable**: the code is well tested, both at the function level; and at the
+  simulation level, checking thermodynamic properties of the systems;
+- **extendable**: the code is modular, object-oriented, well documented,
+  open-source, and easy to read.
 
 Lumol is actively developed, and should be considered as alpha software. If
 you are interested, have some questions or want to participate, you can open a
-Github issue or go to the project [chat room][Gitter].
-
-[Gitter]: https://gitter.im/lumol-org/lumol
+[Github issue][issues] or go to the project [chat room][Gitter].
 
 ## Features
 
-Currently, the following algorithms are implemented:
-- Pair and molecular interactions;
-- Generic methods for interactions evaluation;
-- Support for user-defined potentials in an ergonomic way;
-- Electrostatic interactions using Ewald or Wolf method;
+- Pair, molecular and electrostatic interactions (with Ewald or Wolf methods);
 - Energy minimization;
 - Molecular dynamics simulations in the NVE, NVT and NPT ensembles;
 - Monte-Carlo simulations in the NVT ensemble;
-
-In a short-term, I'd like to add:
-- Monte-Carlo moves for the NPT and µVT ensembles;
-- Extended ensemble (Nose-Hoover) integration for molecular dynamics;
+- and many others! Have a look at the [documentation](#documentation) for more
+  information
 
 ## Getting started
 
-Lumol is usable both as a Rust library to write your own simulation code
-using the provided bricks, and as a ready to use command line tool for running
-simulations.
+Lumol provides both a command line tool for running simulations; and a Rust
+library for writing your own simulations algorithms using the pre-existing
+building blocks.
+
+### Documentation
+
+Documentation is hosted [here](http://lumol-org.github.io/lumol), and separated
+in two parts:
+
+- The [user manual][user_manual] contains information on how to use Lumol as a
+  command line tool, and the complete input file documentation. Use this
+  documentation if you want to use Lumol as a simulation engine — without
+  writing code.
+- To use Lumol as a library inside your own code, we have a [developer
+  documentation][devdoc], which contains documentation for all the library
+  public functions, and examples for most of them.
 
 ### Installation as a command line tool
-
-[Rust]: https://www.rust-lang.org/downloads.html
 
 You will need a stable Rust compiler, [grab one][Rust] if you do not have one
 yet. Then, you can download the code, build it and install it by running:
@@ -57,55 +64,32 @@ cargo install --git https://github.com/lumol-org/lumol
 
 This will produce the a `lumol` binary in `~/.cargo/bin`.
 
-### Usage as a library & developement
+### Usage as a library
 
-You can also clone and build lumol locally, for developing it or using it as a
-library by running:
+You can add Lumol as a dependency in your project's `Cargo.toml`:
 
-```bash
-git clone https://github.com/lumol-org/lumol
-cd lumol
-cargo build
+```toml
+[dependencies]
+lumol = {git = "https://github.com/lumol-org/lumol"}
 ```
 
-Various options for use are in the `examples` directory. You can build them by running
-`cargo test --release --no-run`; and run them from the `examples` directory.
-
-We also have unit and integration tests that you can run with:
-
-```bash
-# Run only the unit test
-cargo test --lib
-# Run all the tests in release mode.
-cargo test --release
-```
-
-Any failing test is an issue, please [report it][NewIssue]!
-
-[NewIssue]: https://github.com/lumol-org/lumol/issues/new
-
-### Documentation
-
-Documentation is hosted [here](http://lumol-org.github.io/lumol), and separated
-in two main parts:
-
-- The [user manual](http://lumol-org.github.io/lumol/latest/book/) contains
-  information on how to use lumol as a command line tool, and the complete input
-  file documentation. Use this documentation if you want to use Lumol as a
-  simulation engine — without writing code.
-- To use Lumol as a library inside your own code, we have a [developer
-  documentation](http://lumol-org.github.io/lumol/latest/lumol/), which
-  should be complete with all functions documented.
+A tutorial about how to implement new algorithms in Lumol is coming. While
+waiting, you can ask your questions [here][Gitter].
 
 ## Contributing
 
-If you want to contribute to Lumol, there are several ways to go: improving
-the documentation and helping with language issues; testing the code on your
-systems to find bugs; adding new algorithms and potentials; providing feature
-requests. Please come by and [talk with us][Gitter] a bit before staring new
-work, or open an [issue][NewIssue] to discuss improvements. We also have
-[recomendation](https://github.com/lumol-org/lumol/blob/master/Contributing.md)
-for contributors.
+If you want to contribute to Lumol, there are several ways to go: improving the
+documentation and helping with language issues; testing the code on your systems
+to find bugs; adding new algorithms and potentials; providing feature requests.
+Please come by and [talk with us][Gitter] a bit before staring new work, or open
+an [issue][issues] to discuss improvements. We also have
+[recommendations][contributing] for contributors.
+
+Lumol was created and is maintained by [Guillaume
+Fraux](https://github.com/Luthaf). Contributors to the code include, in
+alphabetic order:
+- [Gernot Bauer](https://github.com/g-bauer)
+- [Guillaume Fraux](https://github.com/Luthaf)
 
 ## License
 
@@ -115,3 +99,10 @@ text.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, shall be licensed under the same BSD license,
 without any additional terms or conditions.
+
+[Rust]: https://www.rust-lang.org/downloads.html
+[Gitter]: https://gitter.im/lumol-org/lumol
+[issues]: https://github.com/lumol-org/lumol/issues/new
+[contributing]: Contributing.md
+[user_manual]: http://lumol-org.github.io/lumol/latest/book/
+[devdoc]: http://lumol-org.github.io/lumol/latest/lumol/


### PR DESCRIPTION
This contains improvements for the language and update the build instructions for Lumol.

- [New README](https://github.com/lumol-org/lumol/blob/fcbd01120e275f3985815f48223dc287af9f81bf/README.md)
- [New contributor instructions](https://github.com/lumol-org/lumol/blob/fcbd01120e275f3985815f48223dc287af9f81bf/Contributing.md)

It also change the goals of the framework to be **flexible**, **reliable** and **extensible**. I did not put fast and parallel in them, because I want to wait for #49 verdict before saying so; and because the code is not yet parallel (see #56 for the discussion about this).

Do you agree with this set of goal? Am I missing something?