### PR TITLE
Add setup function for MCMove

### DIFF
--- a/src/core/src/sim/mc/monte_carlo.rs
+++ b/src/core/src/sim/mc/monte_carlo.rs
@@ -145,7 +145,7 @@ impl Propagator for MonteCarlo {
     fn setup(&mut self, system: &System) {
         self.normalize_frequencies();
         self.cache.init(system);
-        for mc_move in self.moves.iter_mut() {
+        for mc_move in &mut self.moves {
             mc_move.0.setup(system)
         } 
     }
@@ -200,12 +200,12 @@ impl Propagator for MonteCarlo {
 
     /// Print some informations about moves to screen
     fn finish(&mut self, _: &System) {
-        println!("Monte Carlo simulation summary");
+        info!("Monte Carlo simulation summary");
         for mc_move in self.moves.iter() {
-            println!("Statistics for move: {}", mc_move.0.describe());
-            println!("  Calls     : {}", mc_move.1.ncalled);
-            println!("  Acceptance: {} %", mc_move.1.naccepted as f64 /
-             mc_move.1.nattempted as f64 * 100.0);
+            info!("Statistics for move: {}", mc_move.0.describe());
+            info!("  Calls     : {}", mc_move.1.ncalled);
+            info!("  Acceptance: {} %", mc_move.1.naccepted as f64 /
+                mc_move.1.nattempted as f64 * 100.0);
         }
     }
 }
@@ -246,7 +246,7 @@ impl MoveCounter {
             let ta = target_acceptance.unwrap();
             if ta >= 1.0 || ta <= 0.0 {
                 fatal_error!(
-                    "The target acceptance ratio of the move has to be a positive value 0.0 <= ta < 1.0"
+                    "The target acceptance ratio of the move has to be a positive value 0.0 < ta < 1.0"
                 )
             }
         }
@@ -326,13 +326,18 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn invalid_acceptance() {
+    fn too_large_acceptance() {
         let mut mc = MonteCarlo::new(100.0);
         mc.add_move_with_acceptance(Box::new(DummyMove), 1.0, 0.5);
         mc.moves[0].1.set_acceptance(Some(1.1));
-        mc.moves[0].1.set_acceptance(Some(0.0));
     }
 
+    #[test]
+    #[should_panic]
+    fn negative_acceptance() {
+        let mut mc = MonteCarlo::new(100.0);
+        mc.add_move_with_acceptance(Box::new(DummyMove), 1.0, -0.1);
+    }
     #[test]
     fn valid_acceptance() {
         let mut mc = MonteCarlo::new(100.0);

--- a/src/core/src/sim/mc/moves/mod.rs
+++ b/src/core/src/sim/mc/moves/mod.rs
@@ -18,6 +18,9 @@ pub trait MCMove {
     /// Give a short description of this move
     fn describe(&self) -> &str;
 
+    /// Set up move before simulation is run 
+    fn setup(&mut self, system: &System);
+    
     /// Prepare the move by selecting the particles to move, and the parameters
     /// of the move. The `rng` random number generator should be used to
     /// generate the parameters of the move.

--- a/src/core/src/sim/mc/moves/rotate.rs
+++ b/src/core/src/sim/mc/moves/rotate.rs
@@ -116,10 +116,12 @@ impl MCMove for Rotate {
 
     fn update_amplitude(&mut self, scaling_factor: Option<f64>) {
         if let Some(s) = scaling_factor {
-            if (s * self.theta).to_degrees() <= 180.0 {
+            if (s * self.theta).abs().to_degrees() <= 180.0 {
                 self.theta *= s;
+                self.range = Range::new(-self.theta, self.theta);
+            } else {
+                warn_once!("Tried to increase the maximum amplitude for rotations to more than 180°! Limiting amplitude to 180°!");
             }
-            self.range = Range::new(-self.theta, self.theta);
         }
     }
 }

--- a/src/core/src/sim/mc/moves/rotate.rs
+++ b/src/core/src/sim/mc/moves/rotate.rs
@@ -65,6 +65,8 @@ impl MCMove for Rotate {
     fn describe(&self) -> &str {
         "molecular rotation"
     }
+    
+    fn setup(&mut self, _: &System) { }
 
     fn prepare(&mut self, system: &mut System, rng: &mut Box<Rng>) -> bool {
         if let Some(id) = select_molecule(system, self.moltype, rng) {
@@ -114,7 +116,9 @@ impl MCMove for Rotate {
 
     fn update_amplitude(&mut self, scaling_factor: Option<f64>) {
         if let Some(s) = scaling_factor {
-            self.theta *= s;
+            if (s * self.theta).to_degrees() <= 180.0 {
+                self.theta *= s;
+            }
             self.range = Range::new(-self.theta, self.theta);
         }
     }

--- a/src/core/src/sim/mc/moves/translate.rs
+++ b/src/core/src/sim/mc/moves/translate.rs
@@ -64,6 +64,12 @@ impl MCMove for Translate {
         "molecular translation"
     }
 
+    fn setup(&mut self, _: &System) { 
+        // Maybe introduce a limitation for dr, dr_max, such that it can not 
+        // be larger than the largest cutoff in the system? We would initialize
+        // the value here.
+    }
+
     fn prepare(&mut self, system: &mut System, rng: &mut Box<Rng>) -> bool {
         if let Some(id) = select_molecule(system, self.moltype, rng) {
             self.molid = id;

--- a/src/core/src/sim/mc/moves/translate.rs
+++ b/src/core/src/sim/mc/moves/translate.rs
@@ -65,7 +65,7 @@ impl MCMove for Translate {
     }
 
     fn setup(&mut self, _: &System) { 
-        // Maybe introduce a limitation for dr, dr_max, such that it can not 
+        // TODO: introduce a limitation for dr, dr_max, such that it can not 
         // be larger than the largest cutoff in the system? We would initialize
         // the value here.
     }


### PR DESCRIPTION
This PR adds a `setup` function for `MCMove`.

The interface is identical to the `setup` function for the `Integrator` trait:

```rust
fn setup(&mut self, system: &System) { ... }
```

This can be used to get information from the `System` before the simulation starts. For example, we can get the cutoff radius from the interaction potentials, which is useful to decide how much a cell can be resized or to limit the amplitude of translations.

For the currently implemented moves, `rotate` and `translate`, this function does nothing. For `translate` we might want to add a limitation for the translation range `dr` that can be set here.