### PR TITLE
Add function to get the largest cutoff radius

### DIFF
--- a/src/core/src/energy/pairs.rs
+++ b/src/core/src/energy/pairs.rs
@@ -147,6 +147,11 @@ impl PairInteraction {
     pub fn set_restriction(&mut self, restriction: PairRestriction) {
         self.restriction = restriction;
     }
+
+    /// Return the cutoff radius
+    pub fn get_cutoff(&self) -> f64 {
+        self.cutoff
+    }
 }
 
 impl PairInteraction {
@@ -304,6 +309,8 @@ mod tests {
 
         assert_eq!(pairs.force(4.1), 0.0);
         assert_eq!(pairs.energy(4.1), 0.0);
+
+        assert_eq!(pairs.get_cutoff(), 4.0);
     }
 
     #[test]

--- a/src/core/src/energy/pairs.rs
+++ b/src/core/src/energy/pairs.rs
@@ -149,6 +149,18 @@ impl PairInteraction {
     }
 
     /// Return the cutoff radius
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lumol::energy::PairInteraction;
+    /// use lumol::energy::LennardJones;
+    ///
+    /// let ar = LennardJones{sigma: 3.405, epsilon: 1.0};
+    /// let interaction = PairInteraction::new(Box::new(ar), 9.1935);
+    /// let rc = interaction.get_cutoff();
+    /// assert_eq!(rc, 2.7f64 * 3.405);
+    /// ```
     pub fn get_cutoff(&self) -> f64 {
         self.cutoff
     }

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -185,6 +185,20 @@ impl Interactions {
         }
     }
 
+    /// Get all pair interactions
+    ///
+    /// Using this function, you lose information
+    /// about which interaction belongs to which pair of particles.
+    pub fn all_pairs(&self) -> Vec<&PairInteraction> {
+        let res: Vec<&PairInteraction> = self.pairs
+            .values() // value is a Vec<&PairInteraction>
+            // flatten the vector -> return an iterator over
+            // Vec<&PairInteraction>
+            .flat_map(|i| i)
+            .collect();
+        res
+    }
+
     /// Get all bonded interactions corresponding to the pair `(i, j)`
     pub fn bonds(&self, i: Kind, j: Kind) -> &[Box<BondPotential>] {
         let (i, j) = sort_pair(i, j);
@@ -278,6 +292,7 @@ mod test {
         assert_eq!(interactions.pairs(Kind(0), Kind(0)).len(), 0);
         interactions.add_pair("H", "H", pair.clone());
         assert_eq!(interactions.pairs(Kind(0), Kind(0)).len(), 1);
+        assert_eq!(interactions.all_pairs().len(), 2);
     }
 
     #[test]

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -190,13 +190,9 @@ impl Interactions {
     /// Using this function, you lose information
     /// about which interaction belongs to which pair of particles.
     pub fn all_pairs(&self) -> Vec<&PairInteraction> {
-        let res: Vec<&PairInteraction> = self.pairs
-            .values() // value is a Vec<&PairInteraction>
-            // flatten the vector -> return an iterator over
-            // Vec<&PairInteraction>
-            .flat_map(|i| i)
-            .collect();
-        res
+        self.pairs.values()        // get an iterator over map values
+                  .flat_map(|i| i) // flatten nested vectors
+                  .collect()       // collect into Vec<&PairInteraction>
     }
 
     /// Get all bonded interactions corresponding to the pair `(i, j)`

--- a/src/core/src/sys/systems.rs
+++ b/src/core/src/sys/systems.rs
@@ -265,7 +265,6 @@ impl System {
         let _ = self.molids.remove(i);
     }
 
-
     /// Insert a particle at the end of the internal list
     pub fn add_particle(&mut self, p: Particle) {
         let mut part = p;
@@ -465,6 +464,19 @@ impl System {
         let mkind = self.particles[m].kind;
         self.interactions.dihedrals(ikind, jkind, kkind, mkind)
     }
+
+    /// Return the largest cutoff radius from pair interactions
+    /// excluding electrostatic interactions.
+    pub fn largest_cutoff(&self) -> f64 {
+        let mut largest_rc = 0f64;
+        // iterate over all (intermolecular) pair interactions to extract rc
+        for rc in self.interactions.all_pairs().iter().map(|i| i.get_cutoff()) {
+            if rc > largest_rc {
+                largest_rc = rc
+            };
+        } 
+        largest_rc
+    }
 }
 
 impl<'a> IntoIterator for &'a System {
@@ -637,6 +649,7 @@ impl IndexMut<usize> for System {
 mod tests {
     use sys::*;
     use types::*;
+    use energy::*;
 
     #[test]
     fn step() {
@@ -829,6 +842,21 @@ mod tests {
         assert_eq!(system.bond_potentials(0, 0).len(), 0);
         assert_eq!(system.angle_potentials(0, 0, 0).len(), 0);
         assert_eq!(system.dihedral_potentials(0, 0, 0, 0).len(), 0);
+    }
+
+    #[test]
+    fn largest_cutoff() {
+        let mut system = System::new();
+        let small_rc = PairInteraction::new(
+            Box::new(LennardJones{sigma: 3.0, epsilon: 1.0}), 10.0
+        );
+        let large_rc = PairInteraction::new(
+            Box::new(LennardJones{sigma: 2.0, epsilon: 1.0}), 14.0
+        );
+        system.interactions.add_pair("A", "B", small_rc);
+        assert_eq!(system.largest_cutoff(), 10.0);
+        system.interactions.add_pair("A", "C", large_rc);
+        assert_eq!(system.largest_cutoff(), 14.0);
     }
 
     #[test]

--- a/src/core/src/sys/systems.rs
+++ b/src/core/src/sys/systems.rs
@@ -464,19 +464,6 @@ impl System {
         let mkind = self.particles[m].kind;
         self.interactions.dihedrals(ikind, jkind, kkind, mkind)
     }
-
-    /// Return the largest cutoff radius from pair interactions
-    /// excluding electrostatic interactions.
-    pub fn largest_cutoff(&self) -> f64 {
-        let mut largest_rc = 0f64;
-        // iterate over all (intermolecular) pair interactions to extract rc
-        for rc in self.interactions.all_pairs().iter().map(|i| i.get_cutoff()) {
-            if rc > largest_rc {
-                largest_rc = rc
-            };
-        } 
-        largest_rc
-    }
 }
 
 impl<'a> IntoIterator for &'a System {
@@ -649,7 +636,6 @@ impl IndexMut<usize> for System {
 mod tests {
     use sys::*;
     use types::*;
-    use energy::*;
 
     #[test]
     fn step() {
@@ -842,21 +828,6 @@ mod tests {
         assert_eq!(system.bond_potentials(0, 0).len(), 0);
         assert_eq!(system.angle_potentials(0, 0, 0).len(), 0);
         assert_eq!(system.dihedral_potentials(0, 0, 0, 0).len(), 0);
-    }
-
-    #[test]
-    fn largest_cutoff() {
-        let mut system = System::new();
-        let small_rc = PairInteraction::new(
-            Box::new(LennardJones{sigma: 3.0, epsilon: 1.0}), 10.0
-        );
-        let large_rc = PairInteraction::new(
-            Box::new(LennardJones{sigma: 2.0, epsilon: 1.0}), 14.0
-        );
-        system.interactions.add_pair("A", "B", small_rc);
-        assert_eq!(system.largest_cutoff(), 10.0);
-        system.interactions.add_pair("A", "C", large_rc);
-        assert_eq!(system.largest_cutoff(), 14.0);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds functionality to access the largest cutoff from all `pairs`. This is useful to get the limit of the smallest simulation cell.

Currently, only pair interactions are considered, no electrostatics.