### PR TITLE
Debug cache: move_particle_cost

### DIFF
--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -162,21 +162,6 @@ impl EnergyCache {
             }
         }
 
-        // Interactions withing the sub-system being moved
-        for (i, &part_i) in idxes.iter().enumerate() {
-            for (j, &part_j) in idxes.iter().enumerate().skip(i + 1) {
-                let r = system.cell().distance(&newpos[i], &newpos[j]);
-                let energy = evaluator.pair(r, part_i, part_j);
-
-                pairs_delta += energy;
-                new_pairs[(part_i, part_j)] += energy;
-                new_pairs[(part_j, part_i)] += energy;
-
-                pairs_delta -= self.pairs_cache[(part_i, part_j)];
-            }
-        }
-
-
         // Recompute everything here. One day we could store some terms and do
         // the same thing than for pair interactions.
         let mut bonds = 0.0;
@@ -240,11 +225,12 @@ impl EnergyCache {
             let (n, m) = new_pairs.shape();
             debug_assert!(n == m);
             debug_assert!((n, m) == cache.pairs_cache.shape());
-            for i in 0..n {
+            // only loop over the indices that actually changed
+            for i in idxes.iter() {
                 for j in 0..n {
-                    if new_pairs[(i, j)] != 0.0 {
-                        cache.pairs_cache[(i, j)] = new_pairs[(i, j)];
-                    }
+                    if idxes.contains(&j) {continue}
+                    cache.pairs_cache[(*i, j)] = new_pairs[(*i, j)];
+                    cache.pairs_cache[(j, *i)] = new_pairs[(*i, j)];
                 }
             }
             // Update the cache for the global potentials


### PR DESCRIPTION
This PR addresses two topics:

### 1) Fix the bug from #64 

The bug was in the update closure [here](https://github.com/lumol-org/lumol/blob/12ebbf6379da4178eb4ca62a866a04f762979f18/src/core/src/sys/cache.rs#L245).

Imagine particle `i` moves away from particle `j` so that the old distance is `r_old < rc` and the new distance is `r_new > rc`. It's now at a distance larger than the cutoff which will lead to `energy_old != 0.0 -> energy_new = 0.0`. In the current state, this true energy will be skipped due to the if-clause. 

See [this](https://github.com/g-bauer/jupyter_notebooks/blob/master/cache_energy_debugged.ipynb) notebook for a simulation with the changes.

### 2) Add tail corrections to the cache.