### PR TITLE
Specify the linker for windows cross compilation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.i686-pc-windows-gnu]
+linker = "i686-w64-mingw32-gcc"
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"


### PR DESCRIPTION
Hi there, it's nice to provide executables for multiple platforms and I just realised rust makes this dead easy. However, it seems like when you execute a cross compilation command:
```
cargo build --target x86_64-pc-windows-gnu
```
it tries to use the normal `gcc` as the linker, so I added this bit of config to have the cross compilation work for windows.

Let me know if you want me to document de cross compilation process a bit more in depht.