### PR TITLE
[DO NOT MERGE] Generate struct of array version of Vec<Particle>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ license = "BSD"
 [workspace]
 members = [
 	"src/core",
-    "src/input"
+    "src/input",
+    "src/macros",
 ]
 
 [[bin]]

--- a/src/macros/Cargo.toml
+++ b/src/macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lumol-macros"
+version = "0.1.0"
+authors = ["Luthaf <luthaf@luthaf.fr>"]
+documentation = "https://lumol-org.github.io/lumol"
+repository = "https://github.com/lumol-org/lumol"
+readme = "../../README.md"
+license = "BSD"
+
+[dependencies]
+syn = "0.10"
+quote = "0.3"
+
+[lib]
+proc-macro = true

--- a/src/macros/src/lib.rs
+++ b/src/macros/src/lib.rs
@@ -1,0 +1,81 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) 2015-2016 G. Fraux — BSD license
+extern crate proc_macro;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use syn::{Body, VariantData, MacroInput};
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(StructOfArray)]
+pub fn soa_derive(input: TokenStream) -> TokenStream {
+    let source = input.to_string();
+    let ast = syn::parse_macro_input(&source).unwrap();
+    let generated = derive_vec(&ast);
+    generated.parse().unwrap()
+}
+
+fn derive_vec(input: &MacroInput) -> quote::Tokens {
+    let ident = &input.ident;
+    let soa_ident = quote::Ident::from(format!("{}Vec", input.ident));
+    let fields = match input.body {
+        Body::Struct(ref data) => {
+            match data {
+                &VariantData::Struct(ref fields) => fields.clone(),
+                _ => panic!("#[derive(SoA)] only supports structs."),
+            }
+        }
+        _ => panic!("#[derive(SoA)] only supports structs."),
+    };
+
+    let vec_fields = fields.iter()
+        .map(|f| {
+            let field_ident = f.ident.clone().unwrap();
+            let field_ty = &f.ty;
+            quote!{
+                pub #field_ident: Vec<#field_ty>
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let field_idents = fields.iter().map(|f| f.ident.clone().unwrap()).collect::<Vec<_>>();
+    let field_idents_1 = &field_idents;
+    let field_idents_2 = &field_idents;
+
+    let first_ident = &field_idents[0];
+
+    quote!{
+        #[derive(Debug)]
+        struct #soa_ident {
+            #(
+                #vec_fields,
+            )*
+        }
+
+        impl #soa_ident {
+            pub fn new() -> Self {
+                #soa_ident {
+                    #(
+                        #field_idents_1 : Vec::new(),
+                    )*
+                }
+            }
+
+            pub fn push(&mut self, value: #ident) {
+                let #ident{#(#field_idents_1),*} = value;
+                #(
+                    self.#field_idents_1.push(#field_idents_2);
+                )*
+            }
+
+            pub fn len(&self) -> usize {
+                let len = self.#first_ident.len();
+                #(
+                    debug_assert_eq!(self.#field_idents_1.len(), len);
+                )*
+                len
+            }
+        }
+    }
+}

--- a/src/macros/tests/derive.rs
+++ b/src/macros/tests/derive.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate lumol_macros;
+
+#[derive(Debug, StructOfArray)]
+struct Particle {
+    name: String,
+    mass: f64
+}
+
+impl Particle {
+    pub fn new(name: String, mass: f64) -> Self {
+        Particle {
+            name: name,
+            mass: mass,
+        }
+    }
+}
+
+#[test]
+fn push() {
+    let mut particles = ParticleVec::new();
+    particles.push(Particle::new(String::from("Na"), 56.0));
+
+    assert_eq!(particles.name[0], "Na");
+    assert_eq!(particles.mass[0], 56.0);
+}
+
+#[test]
+fn len() {
+    let mut particles = ParticleVec::new();
+    assert_eq!(particles.len(), 0);
+
+    particles.push(Particle::new(String::from("Na"), 56.0));
+    assert_eq!(particles.len(), 1);
+}


### PR DESCRIPTION
This is an initial and very rough proof-of-concept for using procedural macro to automatically generate all the helper functions and structs needed to do an Array of structs => struct of arrays automatically. For more background on this transformation and why it can be useful, see https://github.com/lumol-org/lumol/issues/18#issuecomment-272833695, and https://en.wikipedia.org/wiki/AOS_and_SOA.

This implementation uses the not-yet-stable procedural macros feature, so you need the beta version of the compiler to compile/test it:

```
rustup toolchain add beta
cd /path/to/lumol
cd src/macros
cargo +beta test
```

---

The code currently generate a single `ParticleVec` struct from a `Particle` definition; I would like to generate equivalents to `&Particle`; `&mut Particle`; `&[Particle]` and `&mut [Particle]` too. It only contains two methods: `push` and `len`, we need to look at all the `Vec` and `[T]` methods to know which one we need to replicate here.

We can not just use `Deref<Target=Vec<Particle>>`, because this is not how the data is laid out in memory.

Here would be an example of which structs would be generated in the [example](https://github.com/lumol-org/lumol/compare/soa-macros?expand=1#diff-e291cfad782d1f093307dfca338f363fR4).
```rust
// Same as &'a Particle, with data inside the ParticleVec
struct ParticleRef<'a> {
    pub name: &'a String,
    pub mass: &'a f64
}

// Same as &'a mut Particle, with data inside the ParticleVec
struct ParticleMut<'a> {
    pub name: &'a mut String,
    pub mass: &'a mut f64
}

// Same as &'a [Particle], with data inside the ParticleVec
struct ParticleSlice<'a> {
    pub name: &'a [String],
    pub mass: &'a [f64]
}

// Same as &'a mut [Particle], with data inside the ParticleVec
struct ParticleSliceMut<'a> {
    pub name: &'a  mut [String],
    pub mass: &'a mut [f64]
}
```

---

Before being merged, this will need us to gather more data on speed gain or loss, and to run more benchmarks.