### PR TITLE
Fix some examples

### DIFF
--- a/examples/data/simulation.toml
+++ b/examples/data/simulation.toml
@@ -4,8 +4,8 @@ version = 1
 [[systems]]
 guess_bonds = true
 cell = 25
-potentials = "data/binary.toml"
-file = "data/binary.xyz"
+potentials = "binary.toml"
+file = "binary.xyz"
 
 [[simulations]]
 nsteps = 100000
@@ -13,8 +13,8 @@ nsteps = 100000
 type = "MonteCarlo"
 temperature = "500 K"
 moves = [
-    {type = "Rotate", delta = "10.0 deg", molecule = "data/CO2.xyz"},
-    {type = "Translate", delta = "0.5 A", molecule = "data/CO2.xyz"},
-    {type = "Rotate", delta = "20 deg", molecule = "data/H2O.xyz", frequency = 2},
-    {type = "Translate", delta = "10 A", molecule = "data/H2O.xyz", frequency = 2},
+    {type = "Rotate", delta = "10.0 deg", molecule = "CO2.xyz"},
+    {type = "Translate", delta = "0.5 A", molecule = "CO2.xyz"},
+    {type = "Rotate", delta = "20 deg", molecule = "H2O.xyz", frequency = 2},
+    {type = "Translate", delta = "10 A", molecule = "H2O.xyz", frequency = 2},
 ]

--- a/examples/xenon.rs
+++ b/examples/xenon.rs
@@ -12,7 +12,7 @@ use lumol::units;
 fn main() {
     Logger::stdout();
 
-    let mut trajectory = Trajectory::open("data/NaCl.xyz").unwrap();
+    let mut trajectory = Trajectory::open("data/xenon.xyz").unwrap();
     let mut system = trajectory.read().unwrap();
     system.set_cell(UnitCell::cubic(units::from(21.65, "A").unwrap()));
 


### PR DESCRIPTION
* the `xenon` example did not use the correct trajectory file
* are the paths in the `toml` files supposed to be relative to the file ? If so I fixed them, if not we have a problem because these examples do not run