### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/Contributing.md
+++ b/Contributing.md
@@ -61,6 +61,11 @@ cd lumol
 cargo build
 ```
 
+Make sure your editor is configured to read the [`.editorconfig`](.editorconfig)
+file. This file is used to specify code formatting rules your editor. Most 
+editors
+[support it natively or have plugin that does](http://editorconfig.org/#download).
+
 Then create a new branch for your changes
 
 ```bash


### PR DESCRIPTION
Ripped from the [crates.io repo](https://github.com/rust-lang/crates.io/blob/master/.editorconfig), this should add more consistency to the formatting (most editors support it), and in particular eliminate the "new line at the end of file" issue.