### PR TITLE
Do not divide by zero when the cell in infinite

### DIFF
--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -30,7 +30,7 @@ use energy::PairRestriction;
 /// ```
 /// use lumol::energy::{GlobalPotential, GlobalCache};
 /// use lumol::types::{Vector3D, Matrix3, Zero};
-/// use lumol::sys::{System, Particle};
+/// use lumol::sys::{System, Particle, UnitCell};
 ///
 /// /// Shift the energy of all the particles by a given delta.
 /// #[derive(Clone)]
@@ -68,7 +68,7 @@ use energy::PairRestriction;
 /// }
 ///
 /// // A simple test
-/// let mut system = System::new();
+/// let mut system = System::from_cell(UnitCell::cubic(10.0));
 /// system.add_particle(Particle::new("Na"));
 /// system.add_particle(Particle::new("Cl"));
 ///

--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -10,7 +10,7 @@ use std::mem;
 use super::MCMove;
 
 use types::{Matrix3, One};
-use sys::{System, EnergyCache, CellShape};
+use sys::{System, EnergyCache};
 
 /// Monte-Carlo move that changes the size of the simulation cell
 pub struct Resize {
@@ -48,7 +48,7 @@ impl MCMove for Resize {
 
     fn setup(&mut self, system: &System) {
         // check if the cell is infinite
-        if system.cell().shape() == CellShape::Infinite {
+        if system.cell().is_infinite() {
             fatal_error!("Cannot use `Resize` move with infinite simulation cell.")
         }
 

--- a/src/core/src/sys/cells.rs
+++ b/src/core/src/sys/cells.rs
@@ -107,6 +107,12 @@ impl UnitCell {
         self.shape
     }
 
+    /// Check if this unit cell is infinite, *i.e.* if it does not have periodic boundary
+    /// conditions.
+    pub fn is_infinite(&self) -> bool {
+        self.shape() == CellShape::Infinite
+    }
+
     /// Get the first vector of the cell
     pub fn vect_a(&self) -> Vector3D {
         let x = self.cell[(0, 0)];
@@ -210,7 +216,7 @@ impl UnitCell {
         }
     }
 
-    /// Get the volume angle of the cell
+    /// Get the volume of the cell
     pub fn volume(&self) -> f64 {
         let volume = match self.shape {
             CellShape::Infinite => 0.0,
@@ -242,6 +248,9 @@ impl UnitCell {
 
     /// Get the reciprocal vectors of this unit cell
     pub fn reciprocal_vectors(&self) -> (Vector3D, Vector3D, Vector3D) {
+        assert!(!self.is_infinite(),
+            "Can not get reciprocal vectors of infinite cells"
+        );
         let volume = self.volume();
         let (a, b, c) = (self.vect_a(), self.vect_b(), self.vect_c());
 
@@ -437,6 +446,7 @@ mod tests {
     fn infinite() {
         let cell = UnitCell::new();
         assert_eq!(cell.shape(), CellShape::Infinite);
+        assert!(cell.is_infinite());
 
         assert_eq!(cell.vect_a(), Vector3D::zero());
         assert_eq!(cell.vect_b(), Vector3D::zero());
@@ -457,6 +467,7 @@ mod tests {
     fn cubic() {
         let cell = UnitCell::cubic(3.0);
         assert_eq!(cell.shape(), CellShape::Orthorombic);
+        assert!(!cell.is_infinite());
 
         assert_eq!(cell.vect_a(), Vector3D::new(3.0, 0.0, 0.0));
         assert_eq!(cell.vect_b(), Vector3D::new(0.0, 3.0, 0.0));
@@ -477,6 +488,7 @@ mod tests {
     fn orthorombic() {
         let cell = UnitCell::ortho(3.0, 4.0, 5.0);
         assert_eq!(cell.shape(), CellShape::Orthorombic);
+        assert!(!cell.is_infinite());
 
         assert_eq!(cell.vect_a(), Vector3D::new(3.0, 0.0, 0.0));
         assert_eq!(cell.vect_b(), Vector3D::new(0.0, 4.0, 0.0));
@@ -497,6 +509,7 @@ mod tests {
     fn triclinic() {
         let cell = UnitCell::triclinic(3.0, 4.0, 5.0, 80.0, 90.0, 110.0);
         assert_eq!(cell.shape(), CellShape::Triclinic);
+        assert!(!cell.is_infinite());
 
         assert_eq!(cell.vect_a(), Vector3D::new(3.0, 0.0, 0.0));
         assert_eq!(cell.vect_b()[2], 0.0);

--- a/src/core/src/sys/energy.rs
+++ b/src/core/src/sys/energy.rs
@@ -53,6 +53,9 @@ impl<'a> EnergyEvaluator<'a> {
     /// Compute the energy due to long range corrections for the pairs
     #[inline]
     pub fn pairs_tail(&self) -> f64 {
+        if self.system.cell().is_infinite() {
+            return 0.0;
+        }
         let mut energy = 0.0;
         let volume = self.system.volume();
         let composition = self.system.composition();
@@ -219,6 +222,15 @@ mod tests {
         let evaluator = EnergyEvaluator::new(&system);
         assert_approx_eq!(evaluator.pairs(), unit_from(-258.3019360389957, "kJ/mol"));
         assert_approx_eq!(evaluator.pairs_tail(), -0.0000028110338032153973);
+    }
+
+    #[test]
+    fn pairs_tail_infinite_cell() {
+        let mut system = testing_system();
+        system.set_cell(UnitCell::new());
+
+        let evaluator = EnergyEvaluator::new(&system);
+        assert_eq!(evaluator.pairs_tail(), 0.0);
     }
 
     #[test]

--- a/src/input/src/simulations/system.rs
+++ b/src/input/src/simulations/system.rs
@@ -50,10 +50,12 @@ impl Input {
         try!(self.read_potentials(&mut system));
         try!(self.init_velocities(&mut system));
 
-        if !with_cell && system.cell().shape() == CellShape::Infinite {
-            warn!("No unit cell in the system, using an infinite unit cell.\n\
-            You can silent this warning by using `cell = []` in the input file \
-            if this is what you want.");
+        if !with_cell && system.cell().is_infinite() {
+            warn!(
+                "No unit cell in the system, using an infinite unit cell.\n\
+                You can get rid of this warning by using `cell = []` in the \
+                input file if this is what you want."
+            );
         }
 
         Ok(system)


### PR DESCRIPTION
Fix #89.

The first commit changes should not be controversial, as we assert that there are not reciprocal vectors and that tail correction does not make sense in infinite cells.

The second one is more open to discussion. When computing pressure/stress/virial, I set the volume to 1 and carry on with the computation.

TODO: 
- [x] Decide what to do for pressure/virial/stress
- [x] Add tests for pressure/virial/stress with infinite cells