### PR TITLE
Add Buckingham and Born-Mayer-Huggins potentials

### DIFF
--- a/doc/src/input/potentials.md
+++ b/doc/src/input/potentials.md
@@ -47,6 +47,40 @@ atoms = ["O", "O"]
 lennardjones = {sigma = "3.16 A", epsilon = "0.155 kcal/mol"}
 ```
 
+## Buckingham potential
+
+The Buckingham potential is a potential for pair interactions expressed as: $$
+V(x) = A \exp(-r / \rho) - \frac{C}{r^6}.$$
+
+The potential type keyword is `buckingham`, and the parameters `A`, `rho`
+($\rho$) and `C` should be provided as strings.
+
+```toml
+[[pairs]]
+atoms = ["A", "B"]
+buckingham = {A = "40 kJ/mol", C = "120e-6 kJ/mol/A^6", rho = "3.0 A"}
+```
+
+## Born-Mayer-Huggins potential
+
+The Born-Mayer-Huggins potential is a potential for pair interactions, used in
+particular for halide alkali. Its expression is: $$ V(x) = A
+\exp\left(\frac{\sigma -r}{\rho}\right) - \frac{C}{r^6} + \frac{D}{r^8}.$$
+
+The potential type keyword is `born`, and the parameters `A`, `C`, `D`, `sigma`
+($\sigma$) and `rho` ($\rho$) should be provided as strings.
+
+```toml
+[[pairs]]
+atoms = ["A", "B"]
+[pairs.born]
+A = "40 kJ/mol"
+C = "120e-6 kJ/mol/A^6"
+D = "23e-6 kJ/mol/A^8"
+rho = "3.0 A"
+sigma = "2.2 A"
+```
+
 ## Harmonic potential
 
 The Harmonic potential is usually used for intramolecular interactions such as

--- a/src/core/src/energy/functions.rs
+++ b/src/core/src/energy/functions.rs
@@ -248,6 +248,72 @@ impl Potential for Torsion {
 impl DihedralPotential for Torsion {}
 
 
+/// Born-Mayer-Huggins potential.
+///
+/// The following potential expression is used: `V(x) = A * exp((sigma - r) /
+/// rho) - C/r^6 + D/r^8`; where `A`, `C` and `D` are energetic constants;
+/// `sigma` and `rho` are length parameters.
+///
+/// # Examples
+///
+/// ```
+/// use lumol::energy::Potential;
+/// use lumol::energy::BornMayerHuggins;
+///
+/// let potential = BornMayerHuggins{a: 2.0, c: 1.0, d: 0.5, sigma: 1.5, rho: 5.3};
+/// assert_eq!(potential.energy(2.2), 1.7446409593340713);
+/// assert_eq!(potential.force(2.2), 0.30992873382584607);
+/// ```
+#[derive(Clone, Copy)]
+pub struct BornMayerHuggins {
+    /// Exponential term energetic constant
+    pub a: f64,
+    /// `1/r^6` term energetic constant
+    pub c: f64,
+    /// `1/r^8` term energetic constant
+    pub d: f64,
+    /// Sphere diameter length constant
+    pub sigma: f64,
+    /// Width of the exponential term length constant
+    pub rho: f64,
+}
+
+impl Potential for BornMayerHuggins {
+    #[inline]
+    fn energy(&self, r: f64) -> f64 {
+        let r2 = r * r;
+        let r6 = r2 * r2 * r2;
+        let exp = f64::exp((self.sigma - r) / self.rho);
+        self.a * exp - self.c / r6 + self.d / (r6 * r2)
+    }
+
+    #[inline]
+    fn force(&self, r: f64) -> f64 {
+        let r2 = r * r;
+        let r7 = r2 * r2 * r2 * r;
+        let exp = f64::exp((self.sigma - r) / self.rho);
+        self.a / self.rho * exp - 6.0 * self.c / r7 + 8.0 * self.d / (r7 * r2)
+    }
+}
+
+impl PairPotential for BornMayerHuggins {
+    fn tail_energy(&self, rc: f64) -> f64 {
+        let rc2 = rc * rc;
+        let rc3 = rc2 * rc;
+        let exp = f64::exp((self.sigma - rc) / self.rho);
+        let factor = rc2 - 2.0 * rc * self.rho + 2.0 * self.rho * self.rho;
+        self.a * self.rho * exp * factor - self.c / (3.0 * rc3) + self.d / (5.0 * rc2 * rc3)
+    }
+
+    fn tail_virial(&self, rc: f64) -> f64 {
+        let rc2 = rc * rc;
+        let rc3 = rc2 * rc;
+        let exp = f64::exp((self.sigma - rc) / self.rho);
+        let factor = rc3 + 3.0 * rc2 * self.rho + 6.0 * rc * self.rho * self.rho + 6.0 * self.rho * self.rho * self.rho;
+        self.a * exp * factor - 20.0 * self.c / rc3 + 8.0 * self.d / (5.0 * rc2 * rc3)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -338,5 +404,21 @@ mod tests {
         let e0 = torsion.energy(4.0);
         let e1 = torsion.energy(4.0 + EPS);
         assert_approx_eq!((e0 - e1)/EPS, torsion.force(4.0), 1e-6);
+    }
+
+    #[test]
+    fn born() {
+        let born = BornMayerHuggins{a: 2.0, c: 1.0, d: 0.5, sigma: 2.0, rho: 2.0};
+
+        // Comparing to externally computed values
+        assert_eq!(born.energy(2.0), 1.986328125);
+        assert_eq!(born.force(2.0), 0.9609375);
+
+        assert_eq!(born.tail_energy(10.0), 4.981521444402363);
+        assert_eq!(born.tail_virial(10.0), 69.13986044386026);
+
+        let e0 = born.energy(4.0);
+        let e1 = born.energy(4.0 + EPS);
+        assert_approx_eq!((e0 - e1)/EPS, born.force(4.0), 1e-6);
     }
 }

--- a/src/core/src/energy/mod.rs
+++ b/src/core/src/energy/mod.rs
@@ -241,7 +241,7 @@ impl_box_clone!(DihedralPotential, BoxCloneDihedral, box_clone_dihedral);
 
 mod functions;
 pub use self::functions::{NullPotential, LennardJones, Harmonic, CosineHarmonic};
-pub use self::functions::{Torsion, BornMayerHuggins};
+pub use self::functions::{Torsion, Buckingham, BornMayerHuggins};
 
 mod computations;
 pub use self::computations::{Computation, TableComputation};

--- a/src/core/src/energy/mod.rs
+++ b/src/core/src/energy/mod.rs
@@ -241,7 +241,7 @@ impl_box_clone!(DihedralPotential, BoxCloneDihedral, box_clone_dihedral);
 
 mod functions;
 pub use self::functions::{NullPotential, LennardJones, Harmonic, CosineHarmonic};
-pub use self::functions::Torsion;
+pub use self::functions::{Torsion, BornMayerHuggins};
 
 mod computations;
 pub use self::computations::{Computation, TableComputation};

--- a/src/core/src/units.rs
+++ b/src/core/src/units.rs
@@ -386,8 +386,8 @@ pub fn from_str(value: &str) -> Result<f64, ParseError> {
     } else {
         try!(UnitExpr::parse(&unit))
     };
-    let value: &str = value.split_whitespace().take(1).collect::<Vec<&str>>()[0];
-    let value: f64 = try!(value.parse());
+    let value = value.split_whitespace().take(1).collect::<Vec<&str>>()[0];
+    let value = try!(value.parse::<f64>());
     return Ok(unit.eval() * value);
 }
 

--- a/src/input/src/interactions/pairs.rs
+++ b/src/input/src/interactions/pairs.rs
@@ -7,6 +7,7 @@ use lumol::units;
 
 use lumol::energy::{PairPotential, PairInteraction, BondPotential};
 use lumol::energy::{Harmonic, LennardJones, NullPotential};
+use lumol::energy::{Buckingham, BornMayerHuggins};
 use lumol::energy::TableComputation;
 
 use error::{Error, Result};
@@ -209,6 +210,8 @@ fn read_pair_potential(pair: &Table) -> Result<Box<PairPotential>> {
             "null" => Ok(Box::new(try!(NullPotential::from_toml(table)))),
             "harmonic" => Ok(Box::new(try!(Harmonic::from_toml(table)))),
             "lj" | "lennardjones" => Ok(Box::new(try!(LennardJones::from_toml(table)))),
+            "buckingham" => Ok(Box::new(try!(Buckingham::from_toml(table)))),
+            "born" => Ok(Box::new(try!(BornMayerHuggins::from_toml(table)))),
             other => Err(
                 Error::from(format!("Unknown potential type '{}'", other))
             ),

--- a/src/input/src/interactions/toml.rs
+++ b/src/input/src/interactions/toml.rs
@@ -8,7 +8,8 @@ use error::{Error, Result};
 use FromToml;
 use FromTomlWithData;
 
-use lumol::energy::{Harmonic, LennardJones, NullPotential, CosineHarmonic, Torsion};
+use lumol::energy::{Harmonic, LennardJones, NullPotential, CosineHarmonic};
+use lumol::energy::{Torsion, Buckingham, BornMayerHuggins};
 use lumol::energy::{Wolf, Ewald};
 use lumol::energy::{PairPotential, TableComputation};
 
@@ -92,8 +93,57 @@ impl FromToml for Torsion {
             Ok(Torsion{n: n as usize, k: k, delta: delta})
         } else {
             Err(
-                Error::from("'k' and 'delta' must be strings in torsion potential, \
-                and 'n' must be an integer")
+                Error::from(
+                    "'k' and 'delta' must be strings in torsion potential, \
+                    and 'n' must be an integer"
+                )
+            )
+        }
+    }
+}
+
+impl FromToml for Buckingham {
+    fn from_toml(table: &Table) -> Result<Buckingham> {
+        let a = try_extract_parameter!(table, "A", "Buckingham potential");
+        let c = try_extract_parameter!(table, "C", "Buckingham potential");
+        let rho = try_extract_parameter!(table, "rho", "Buckingham potential");
+
+        if let (Some(a), Some(c), Some(rho)) = (a.as_str(), c.as_str(), rho.as_str()) {
+            let a = try!(::lumol::units::from_str(a));
+            let c = try!(::lumol::units::from_str(c));
+            let rho = try!(::lumol::units::from_str(rho));
+            Ok(Buckingham{a: a, c: c, rho: rho})
+        } else {
+            Err(
+                Error::from(
+                    "'A', 'C' and 'rho' must be strings in Buckingham potential"
+                )
+            )
+        }
+    }
+}
+
+impl FromToml for BornMayerHuggins {
+    fn from_toml(table: &Table) -> Result<BornMayerHuggins> {
+        let a = try_extract_parameter!(table, "A", "Born-Mayer-Huggins potential");
+        let c = try_extract_parameter!(table, "C", "Born-Mayer-Huggins potential");
+        let d = try_extract_parameter!(table, "D", "Born-Mayer-Huggins potential");
+        let sigma = try_extract_parameter!(table, "sigma", "Born-Mayer-Huggins potential");
+        let rho = try_extract_parameter!(table, "rho", "Born-Mayer-Huggins potential");
+
+        if let (Some(a), Some(c), Some(d), Some(sigma), Some(rho)) =
+               (a.as_str(), c.as_str(), d.as_str(), sigma.as_str(), rho.as_str()) {
+            let a = try!(::lumol::units::from_str(a));
+            let c = try!(::lumol::units::from_str(c));
+            let d = try!(::lumol::units::from_str(d));
+            let sigma = try!(::lumol::units::from_str(sigma));
+            let rho = try!(::lumol::units::from_str(rho));
+            Ok(BornMayerHuggins{a: a, c: c, d: d, sigma: sigma, rho: rho})
+        } else {
+            Err(
+                Error::from(
+                    "'A', 'C', 'D', 'sigma' and 'rho' must be strings in Born-Mayer-Huggins potential"
+                )
             )
         }
     }

--- a/src/input/tests/interactions/bad/toml/born-1.toml
+++ b/src/input/tests/interactions/bad/toml/born-1.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+born = true
+#^ 'born' potential must be a table

--- a/src/input/tests/interactions/bad/toml/born-10.toml
+++ b/src/input/tests/interactions/bad/toml/born-10.toml
@@ -1,0 +1,12 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+rho = "2.3 A"
+#^ Missing 'sigma' in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-11.toml
+++ b/src/input/tests/interactions/bad/toml/born-11.toml
@@ -1,0 +1,12 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+#^ Missing 'rho' in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-2.toml
+++ b/src/input/tests/interactions/bad/toml/born-2.toml
@@ -1,0 +1,13 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = true
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+rho = "2.3 A"
+#^ 'A', 'C', 'D', 'sigma' and 'rho' must be strings in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-3.toml
+++ b/src/input/tests/interactions/bad/toml/born-3.toml
@@ -1,0 +1,13 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = true
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+rho = "2.3 A"
+#^ 'A', 'C', 'D', 'sigma' and 'rho' must be strings in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-4.toml
+++ b/src/input/tests/interactions/bad/toml/born-4.toml
@@ -1,0 +1,13 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+D = true
+sigma = "3.2 A"
+rho = "2.3 A"
+#^ 'A', 'C', 'D', 'sigma' and 'rho' must be strings in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-5.toml
+++ b/src/input/tests/interactions/bad/toml/born-5.toml
@@ -1,0 +1,13 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = true
+rho = "2.3 A"
+#^ 'A', 'C', 'D', 'sigma' and 'rho' must be strings in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-6.toml
+++ b/src/input/tests/interactions/bad/toml/born-6.toml
@@ -1,0 +1,13 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+rho = true
+#^ 'A', 'C', 'D', 'sigma' and 'rho' must be strings in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-7.toml
+++ b/src/input/tests/interactions/bad/toml/born-7.toml
@@ -1,0 +1,12 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+rho = "2.3 A"
+#^ Missing 'A' in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-8.toml
+++ b/src/input/tests/interactions/bad/toml/born-8.toml
@@ -1,0 +1,12 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+rho = "2.3 A"
+#^ Missing 'C' in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/born-9.toml
+++ b/src/input/tests/interactions/bad/toml/born-9.toml
@@ -1,0 +1,12 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+sigma = "3.2 A"
+rho = "2.3 A"
+#^ Missing 'D' in Born-Mayer-Huggins potential

--- a/src/input/tests/interactions/bad/toml/buckingham-1.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-1.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = true
+#^ 'buckingham' potential must be a table

--- a/src/input/tests/interactions/bad/toml/buckingham-2.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-2.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = {A = 34, C = "5e-6 kJ/mol/A^6", rho = "2.3 A"}
+#^ 'A', 'C' and 'rho' must be strings in Buckingham potential

--- a/src/input/tests/interactions/bad/toml/buckingham-3.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-3.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = {A = "4.2 kJ/mol", C = 56, rho = "2.3 A"}
+#^ 'A', 'C' and 'rho' must be strings in Buckingham potential

--- a/src/input/tests/interactions/bad/toml/buckingham-4.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-4.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = {A = "4.2 kJ/mol", C = "5e-6 kJ/mol/A^6", rho = 23}
+#^ 'A', 'C' and 'rho' must be strings in Buckingham potential

--- a/src/input/tests/interactions/bad/toml/buckingham-5.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-5.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = {C = "5e-6 kJ/mol/A^6", rho = "2.3 A"}
+#^ Missing 'A' in Buckingham potential

--- a/src/input/tests/interactions/bad/toml/buckingham-6.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-6.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = {A = "4.2 kJ/mol", rho = "2.3 A"}
+#^ Missing 'C' in Buckingham potential

--- a/src/input/tests/interactions/bad/toml/buckingham-7.toml
+++ b/src/input/tests/interactions/bad/toml/buckingham-7.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+cutoff = "3 A"
+buckingham = {A = "4.2 kJ/mol", C = "5e-6 kJ/mol/A^6"}
+#^ Missing 'rho' in Buckingham potential

--- a/src/input/tests/interactions/good/pairs.toml
+++ b/src/input/tests/interactions/good/pairs.toml
@@ -15,6 +15,23 @@ tail_correction = false
 harmonic = {x0 = "3 A", k = "5.9 kJ/mol/A^2"}
 
 [[pairs]]
+atoms = ["A", "B"]
+null = {}
+
+[[pairs]]
+atoms = ["A", "B"]
+buckingham = {A = "4.2 kJ/mol", C = "5e-6 kJ/mol/A^6", rho = "2.3 A"}
+
+[[pairs]]
+atoms = ["A", "B"]
+[pairs.born]
+A = "4.2 kJ/mol"
+C = "5e-6 kJ/mol/A^6"
+D = "7.6e-5 kJ/mol/A^8"
+sigma = "3.2 A"
+rho = "2.3 A"
+
+[[pairs]]
 # Table computations
 atoms = ["A", "B"]
 null = {}


### PR DESCRIPTION
This PR add the very common Buckingham potential, and the less common Born-Mayer-Huggins potential (derived from the Buckingham potential).

Two questions for the reviewers:
    - I used the expressions from LAMMPS ([born](http://lammps.sandia.gov/doc/pair_born.html), [buckingham](http://lammps.sandia.gov/doc/pair_buck.html)), using `1/rho` instead of `B` in the exponential. [Wikipedia](https://en.wikipedia.org/wiki/Buckingham_potential) and [Sklog Wiki](http://www.sklogwiki.org/SklogWiki/index.php/Buckingham_potential) uses the other form. I prefer the one with rho because it make it clearer it is a length parameter. Is it OK for you?
    - I used the `born` keyword in input instead of the verbose `Born-Mayer-Huggins`, is this OK? I am following LAMMPS here too.

Ref #6 
