### PR TITLE
Fix a threshold in the Ewald summation.

### DIFF
--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -368,7 +368,7 @@ impl Ewald {
                 for ikz in 0..self.kmax {
                     // The k = 0 case and the cutoff in k-space are already
                     // handled in `expfactors`
-                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::MIN {continue}
+                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::EPSILON {continue}
                     let density = self.rho[(ikx, iky, ikz)].norm();
                     energy += self.expfactors[(ikx, iky, ikz)] * density * density;
                 }
@@ -391,7 +391,7 @@ impl Ewald {
                 for ikz in 0..self.kmax {
                     // The k = 0 and the cutoff in k-space are already handled
                     // in `expfactors`.
-                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::MIN {continue}
+                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::EPSILON {continue}
                     let k = (ikx as f64) * rec_kx + (iky as f64) * rec_ky + (ikz as f64) * rec_kz;
                     for i in 0..system.size() {
                         let qi = system[i].charge;
@@ -437,7 +437,7 @@ impl Ewald {
                 for ikz in 0..self.kmax {
                     // The k = 0 and the cutoff in k-space are already handled
                     // in `expfactors`.
-                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::MIN {continue}
+                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::EPSILON {continue}
                     let k = (ikx as f64) * rec_kx + (iky as f64) * rec_ky + (ikz as f64) * rec_kz;
                     for i in 0..system.size() {
                         let qi = system[i].charge;
@@ -512,7 +512,7 @@ impl Ewald {
                 for ikz in 0..self.kmax {
                     // The k = 0 case and the cutoff in k-space are already
                     // handled in `expfactors`.
-                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::MIN {continue}
+                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::EPSILON {continue}
                     let rho = self.rho[(ikx, iky, ikz)] + self.delta_rho[(ikx, iky, ikz)];
                     let density = rho.norm();
                     e_new += self.expfactors[(ikx, iky, ikz)] * density * density;


### PR DESCRIPTION
Leads to a performance boost, on @Luthaf's machine:
``` bash
$ cargo benchcmp --threshold 4 before.log after.log 
 name                            before.log ns/iter  after.log ns/iter  diff ns/iter   diff % 
 cache_move_all_rigid_molecules  1,411,730           1,175,259              -236,471  -16.75% 
 cache_move_particle             243,564             222,067                 -21,497   -8.83% 
 cache_move_particle_ewald       393,670             494,358                 100,688   25.58% 
 cache_move_particle_wolf        107,855             120,929                  13,074   12.12% 
 cache_move_particles            273,819             374,547                 100,728   36.79% 
 energy                          2,206,609           2,341,921               135,312    6.13% 
 energy_ewald                    631,581             664,799                  33,218    5.26% 
 energy_wolf                     516,471             578,804                  62,333   12.07% 
 forces                          2,467,907           2,754,187               286,280   11.60% 
 forces                          1,530,325           1,366,786              -163,539  -10.69% 
 forces_ewald                    36,832,527          24,325,602          -12,506,925  -33.96% 
 forces_ewald                    49,666,722          34,790,514          -14,876,208  -29.95% 
 virial                          3,057,925           3,350,002               292,077    9.55% 
 virial_ewald                    91,684,931          65,127,750          -26,557,181  -28.97% 
 virial_ewald                    137,687,483         92,415,405          -45,272,078  -32.88%
```