### PR TITLE
Improve performance on the Ewald forces

### DIFF
--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -428,15 +428,14 @@ impl Ewald {
     #[inline]
     #[allow(too_many_arguments)]
     fn kspace_force_factor(&self, i: usize, j: usize, ikx: usize, iky: usize, ikz: usize, qi: f64, qj: f64) -> f64 {
-        let fourier_i = self.fourier_phases[(ikx, i, 0)]
-                      * self.fourier_phases[(iky, i, 1)]
-                      * self.fourier_phases[(ikz, i, 2)];
-        let fourier_j = self.fourier_phases[(ikx, j, 0)]
-                      * self.fourier_phases[(iky, j, 1)]
-                      * self.fourier_phases[(ikz, j, 2)];
-        let sin_kr = (fourier_i - fourier_j).imag();
+        let fourier_i = self.fourier_phases[(ikx, i, 0)].imag_mul(
+            self.fourier_phases[(iky, i, 1)] * self.fourier_phases[(ikz, i, 2)]
+        );
+        let fourier_j = self.fourier_phases[(ikx, j, 0)].imag_mul(
+            self.fourier_phases[(iky, j, 1)] * self.fourier_phases[(ikz, j, 2)]
+        );
 
-        return qi * qj * sin_kr;
+        return qi * qj * (fourier_i - fourier_j);
     }
 
     /// k-space contribution to the virial

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -394,13 +394,17 @@ impl Ewald {
                 for ikz in 0..self.kmax {
                     // The k = 0 and the cutoff in k-space are already handled
                     // in `expfactors`.
-                    if self.expfactors[(ikx, iky, ikz)].abs() < f64::EPSILON {continue}
+                    let expfactor = self.expfactors[(ikx, iky, ikz)].abs() ;
+                    if expfactor < f64::EPSILON {continue}
+
+                    let f = expfactor * factor;
+
                     let k = (ikx as f64) * rec_kx + (iky as f64) * rec_ky + (ikz as f64) * rec_kz;
                     for i in 0..system.size() {
                         let qi = system[i].charge;
                         for j in (i + 1)..system.size() {
                             let qj = system[j].charge;
-                            let force = factor * self.kspace_force_factor(i, j, ikx, iky, ikz, qi, qj) * k;
+                            let force = f * self.kspace_force_factor(i, j, ikx, iky, ikz, qi, qj) * k;
                             callback(i, j, force);
                         }
                     }
@@ -432,7 +436,7 @@ impl Ewald {
                       * self.fourier_phases[(ikz, j, 2)];
         let sin_kr = (fourier_i - fourier_j).imag();
 
-        return qi * qj * self.expfactors[(ikx, iky, ikz)] * sin_kr;
+        return qi * qj * sin_kr;
     }
 
     /// k-space contribution to the virial

--- a/src/core/src/types/complex.rs
+++ b/src/core/src/types/complex.rs
@@ -153,10 +153,27 @@ impl Complex {
             imag: -self.imag
         }
     }
+
+    /// Get only the imaginary part of the multiplication.
+    /// # Examples
+    /// ```
+    /// # use lumol::types::Complex;
+    /// let a = Complex::cartesian(3.0, -2.0);
+    /// let b = Complex::cartesian(1.5, -3.0);
+    ///
+    /// assert_eq!(a.imag_mul(b), (a*b).imag());
+    /// assert_eq!(b.imag_mul(a), (a*b).imag());
+    /// ```
+    #[inline]
+    pub fn imag_mul(self, other: Complex) -> f64 {
+        self.real() * other.imag() + self.imag() * other.real()
+    }
 }
 
 impl Add<Complex> for Complex {
     type Output = Complex;
+
+    #[inline]
     fn add(self, other: Complex) -> Complex {
         let x = self.real() + other.real();
         let y = self.imag() + other.imag();
@@ -166,6 +183,8 @@ impl Add<Complex> for Complex {
 
 impl Sub<Complex> for Complex {
     type Output = Complex;
+
+    #[inline]
     fn sub(self, other: Complex) -> Complex {
         let x = self.real() - other.real();
         let y = self.imag() - other.imag();
@@ -175,6 +194,8 @@ impl Sub<Complex> for Complex {
 
 impl Neg for Complex {
     type Output = Complex;
+
+    #[inline]
     fn neg(self) -> Complex {
         Complex{
             real: -self.real,
@@ -185,6 +206,8 @@ impl Neg for Complex {
 
 impl Mul<Complex> for Complex {
     type Output = Complex;
+
+    #[inline]
     fn mul(self, other: Complex) -> Complex {
         let x = self.real() * other.real() - self.imag() * other.imag();
         let y = self.real() * other.imag() + self.imag() * other.real();
@@ -194,6 +217,8 @@ impl Mul<Complex> for Complex {
 
 impl Mul<f64> for Complex {
     type Output = Complex;
+
+    #[inline]
     fn mul(self, other: f64) -> Complex {
         Complex::cartesian(self.real() * other, self.imag() * other)
     }
@@ -201,6 +226,8 @@ impl Mul<f64> for Complex {
 
 impl Mul<Complex> for f64 {
     type Output = Complex;
+
+    #[inline]
     fn mul(self, other: Complex) -> Complex {
         Complex::cartesian(self * other.real(), self * other.imag())
     }
@@ -208,6 +235,8 @@ impl Mul<Complex> for f64 {
 
 impl Div<Complex> for Complex {
     type Output = Complex;
+
+    #[inline]
     fn div(self, other: Complex) -> Complex {
         let r = other.norm2();
         let x = self.real() * other.real() + self.imag() * other.imag();
@@ -219,6 +248,8 @@ impl Div<Complex> for Complex {
 
 impl Div<f64> for Complex {
     type Output = Complex;
+
+    #[inline]
     fn div(self, other: f64) -> Complex {
         let norm = self.norm() / other;
         let phase = self.phase();


### PR DESCRIPTION
This PR introduces the following improvements:
1. in [`Ewald::kspace_force_factor`](https://github.com/lumol-org/lumol/blob/592e171cdbcc34f043f5653b347f97bfdf4e04c0/src/core/src/energy/global/ewald.rs#L416-L422) we perform some useless computations because we use only the imaginary part of a product between complex numbers, I introduced a method in the `Complex` class to change that.
2. I took the `expfactor` out of `Ewald::kspace_force_factor` because it is independent of `i` and `j`
3. I removed some redundant multplications
4. I moved the computation of `fourier_i` because it is independent of `j` 

Point 4. is the big hitter, it gives a 30% speedup. Point 2. also seems to have a big influence (but far less noticeable).