### PR TITLE
[WIP] Run benchmarks on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rust:
     - stable
     - beta
 install:
+    - echo $GITHUB_USER_NAME
     - export PATH=$HOME/.local/bin:$PATH:$HOME/local/bin:$HOME/.cargo/bin
     - export CC=gcc-4.9
     - export CXX=g++-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,13 @@ install:
       else
           cargo install mdbook
       fi
+    # Build and cache cargo-benchcmp
+    - |
+      if [ -f $HOME/.cargo/bin/cargo-benchcmp ]; then
+          echo "Using cached cargo-benchcmp from ~/.cargo/bin/cargo-benchcmp"
+      else
+          cargo install cargo-benchcmp
+      fi
     # Clean any cached test executable
     - rm -f target/debug/*-*
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ script:
     - cargo test -p lumol-input
     # Check that benchmarks still compile
     - cargo bench --no-run
+    # Run benchmarks if __TRAVIS_RUN_BENCHES=[n_commits] appears in the commit msg
+    - python scripts/run-benchmarks.py
     # Misc style checking
     - python scripts/check-whitespaces.py
     # Generate and publish coverage

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -24,6 +24,8 @@ COMPARISON_TEMPLATE = """
 </p></details>
 """
 
+BASE_REPO_URL = 'https://github.com/lumol-org/lumol.git'
+
 
 def get_pull_request_id():
     pr_id = os.environ.get('TRAVIS_PULL_REQUEST', 'false')
@@ -34,8 +36,8 @@ def get_pull_request_id():
 
 def request_api(endpoint, data=None):
     url = 'https://api.github.com/repos/lumol-org/lumol' + endpoint
-    username = os.environ['GITHUB_USER_NAME']
-    token = os.environ['GITHUB_USER_TOKEN']
+    username = os.environ['LUMOL_BOT_GH_USERNAME']
+    token = os.environ['LUMOL_BOT_GH_TOKEN']
 
     cmd = "curl -sS %s  -u '%s:%s'" % (url, username, token)
     if data is not None:
@@ -46,7 +48,7 @@ def request_api(endpoint, data=None):
 
 
 def check_if_benches_should_run():
-    EXPR = '@bot benchmark'
+    EXPR = '[lumol bench '
     pr_id = get_pull_request_id()
     if pr_id is None:
         print("This is not a PR, the benchmarks are not run.")
@@ -54,7 +56,6 @@ def check_if_benches_should_run():
 
     # Get the text of the PR in `body`
     out = request_api('/pulls/%s' % pr_id)
-
     clone_url = out['head']['repo']['clone_url']
     body = out['body']
 
@@ -66,7 +67,7 @@ def check_if_benches_should_run():
     end = len(body)
     try:
         s = begin + len(EXPR) + 1
-        end = body[s:].index(' ') + s
+        end = body[s:].index(']') + s
     except ValueError:
         pass
 
@@ -75,15 +76,39 @@ def check_if_benches_should_run():
     return int(n_commits), clone_url
 
 
+def get_master_commit():
+    cmd = 'git log --oneline upstream/master -n 1'
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    h, _, title = out.rstrip().partition(' ')
+    return h, title
+
+
 def get_commit_descriptions(n_commits):
+    """
+    Get hash and title of the `n_commits` latest commits on the branch.
+
+    Also adds the commit at the HEAD of master in the end. If this
+    commit is met earlier, stops at this commit (the master commit
+    is guaranteed to be at the end of the result.
+
+    :param n_commits:
+    :return:
+    """
     cmd = 'git log --oneline | head -n %s' % n_commits
     out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    master_h, master_title = get_master_commit()
+
     descriptions = []
     for line in out.split('\n'):
         if line.rstrip() == '':
             continue
         h, _, title = line.partition(' ')
         descriptions.append((h, title))
+        if h == master_h:
+            break
+
+    if descriptions[-1][0] != master_h:
+        descriptions.append((master_h, master_title))
 
     return descriptions
 
@@ -100,11 +125,11 @@ def run_bench(k):
     subprocess.call('cargo bench > ../bench_%s.txt' % k, shell=True)
 
 
-def run_benches_for_n_commits(n_commits):
-    for k in range(n_commits):
-        print('=================== Benching commit %s ==============================' % k)
-        run_bench(k)
-        subprocess.call('git checkout HEAD~', shell=True)
+def run_benches_for_n_commits(description):
+    for h, title in description:
+        print('=================== Benching commit %s ==============================' % h)
+        subprocess.call('git checkout %s' % h, shell=True)
+        run_bench(h)
         print('=================== Done ==============================')
 
 
@@ -114,17 +139,18 @@ def cd_to_cloned_repo(url):
     subprocess.call('pwd', shell=True)
     subprocess.call('git checkout %s' % os.environ['TRAVIS_PULL_REQUEST_BRANCH'], shell=True)
     subprocess.call('git status', shell=True)
+    subprocess.call('git remote add upstream %s' % BASE_REPO_URL, shell=True)
+    subprocess.call('git fetch upstream master', shell=True)
 
 
-def comment_pull_request(n_commits):
+def comment_pull_request(descriptions):
     pr_id = get_pull_request_id()
-    descriptions = get_commit_descriptions(n_commits)
 
     # Comparison benchmarks
-    comment = '## Comparison benchmarks\n (comparisons with %s)' % descriptions[-1][0]
+    comment = '## Comparing to master (%s)\nusing `--threshold 2`' % descriptions[-1][0]
 
     for k, (h, title) in enumerate(descriptions[:-1]):
-        cmd = 'cargo benchcmp ../bench_%s.txt ../bench_%s' % (n_commits - 1, k)
+        cmd = 'cargo benchcmp ../bench_%s.txt ../bench_%s.txt --threshold 2' % (descriptions[-1][0], h)
         out = subprocess.check_output(cmd, shell=True).decode('utf-8')
         comment += COMPARISON_TEMPLATE % (h, title, out)
 
@@ -132,7 +158,7 @@ def comment_pull_request(n_commits):
     comment += '\n## Individual benchmarks\n'
 
     for k, (h, title) in enumerate(descriptions):
-        with open('../bench_%s.txt' % k) as f:
+        with open('../bench_%s.txt' % h) as f:
             bench = f.read()
         comment += INDIVIDUAL_BENCH_TEMPLATE % (h, title, bench)
 
@@ -149,10 +175,12 @@ def main():
         return
     n_commits, clone_url = result
     cd_to_cloned_repo(clone_url)
+    descriptions = get_commit_descriptions(n_commits)
     run_warmup()
-    run_benches_for_n_commits(n_commits)
-    comment_pull_request(n_commits)
+    run_benches_for_n_commits(descriptions)
+    comment_pull_request(descriptions)
     subprocess.call('rm ../bench_*.txt', shell=True)
+    subprocess.call('rm -rf ../cloned_repo', shell=True)
 
 
 if __name__ == '__main__':

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -150,7 +150,7 @@ def comment_pull_request(descriptions):
     comment = '## Comparing to master (%s)\nusing `--threshold 2`' % descriptions[-1][0]
 
     for k, (h, title) in enumerate(descriptions[:-1]):
-        cmd = 'cargo benchcmp ../bench_%s.txt ../bench_%s.txt --threshold 2' % (descriptions[-1][0], h)
+        cmd = 'cargo benchcmp ../bench_%s.txt ../bench_%s.txt --threshold 2 --variance' % (descriptions[-1][0], h)
         out = subprocess.check_output(cmd, shell=True).decode('utf-8')
         comment += COMPARISON_TEMPLATE % (h, title, out)
 

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -170,6 +170,10 @@ def comment_pull_request(descriptions):
 
 
 def main():
+    if os.environ['TRAVIS_RUST_VERSION'] != 'stable':
+        print('Benchmarks are run only on stable')
+        return
+
     result = check_if_benches_should_run()
     if result is None:
         return

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -1,0 +1,55 @@
+import subprocess
+
+
+def check_if_benches_should_run():
+    EXPR = '__TRAVIS_RUN_BENCHES='
+    out = subprocess.check_output('git log -n 1', shell=True).decode('utf-8')
+
+    for line in out.split('\n'):
+        # If the EXPR appears in the line, return the given value
+        try:
+            idx = line.index(EXPR)
+            return int(line[idx + len(EXPR):])
+        except ValueError:
+            continue
+
+    return None
+
+
+def run_warmup():
+    print('=================== Warming up ==============================')
+    for _ in range(3):
+        subprocess.check_output('cargo bench', shell=True)
+
+
+def run_benches():
+    subprocess.call('cargo bench', shell=True)
+
+
+def run_benches_for_n_commits(n_commits):
+    # Store the name of the current branch
+    current_branch_name = subprocess \
+        .check_output('git rev-parse --abbrev-ref HEAD', shell=True) \
+        .decode('utf-8').rstrip()
+
+    for k in range(n_commits):
+        print('=================== Benching commit %s ==============================' % k)
+        run_benches()
+        subprocess.call('git checkout HEAD~', shell=True)
+        print('=================== Done ==============================')
+
+    # Go back to the commit handled by the CI
+    subprocess.call('git checkout %s' % current_branch_name, shell=True)
+
+
+def main():
+    n_commits = check_if_benches_should_run()
+    if n_commits is not None:
+        run_warmup()
+        run_benches_for_n_commits(n_commits)
+    else:
+        print("No benchmarks were run.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -1,9 +1,14 @@
 import subprocess
+import json
+import os
 
 
 def check_if_benches_should_run():
     EXPR = '__TRAVIS_RUN_BENCHES='
     out = subprocess.check_output('git log -n 1', shell=True).decode('utf-8')
+    print(os.environ.get('TRAVIS_COMMIT_MESSAGE', 'NO COMMIT MSG'))
+    print(os.environ.get('TRAVIS_COMMIT', 'NO COMMIT'))
+    print(os.environ.get('TRAVIS_PULL_REQUEST_BRANCH', 'NO COMMIT'))
 
     for line in out.split('\n'):
         # If the EXPR appears in the line, return the given value
@@ -32,6 +37,8 @@ def run_benches_for_n_commits(n_commits):
         .check_output('git rev-parse --abbrev-ref HEAD', shell=True) \
         .decode('utf-8').rstrip()
 
+    os.mkdir('bench_results')
+
     for k in range(n_commits):
         print('=================== Benching commit %s ==============================' % k)
         run_benches()
@@ -42,11 +49,51 @@ def run_benches_for_n_commits(n_commits):
     subprocess.call('git checkout %s' % current_branch_name, shell=True)
 
 
+def get_pull_request_id():
+    pr_id = os.environ.get('TRAVIS_PULL_REQUEST', 'false')
+    if pr_id == 'false':
+        return None
+    return int(pr_id)
+
+
+def cd_to_cloned_repo():
+    url = 'git@github.com:lumol-org/lumol.git'
+    subprocess.call('git clone %s cloned_repo' % url)
+    os.chdir('cloned_repo')
+    subprocess.call('git status')
+
+
+def comment_pull_request(comment):
+    pr_id = get_pull_request_id()
+    print(pr_id)
+    username = os.environ.get('GITHUB_USER_NAME', None)
+    token = os.environ.get('GITHUB_USER_TOKEN', None)
+
+    if username is None:
+        print('GITHUB_USER_NAME is not set, unable to comment PR.')
+
+    if token is None:
+        print('GITHUB_USER_TOKEN is not set, unable to comment PR.')
+
+    data = {
+        'body': comment
+    }
+    url = 'https://api.github.com/repos/lumol-org/lumol/issues/%s/comments' % pr_id
+    cmd = "curl -i %s --data '%s' -u '%s:%s'" % (url, json.dumps(data), username, token)
+    print("Calling %s" % cmd)
+    subprocess.call(cmd, shell=True)
+
+
 def main():
     n_commits = check_if_benches_should_run()
     if n_commits is not None:
+        if get_pull_request_id() is None:
+            print("This is not a PR, the benchmarks are not ran.")
+        cd_to_cloned_repo()
+        comment_pull_request("Test comment from Travis CI")
         run_warmup()
         run_benches_for_n_commits(n_commits)
+        os.chdir('../')
     else:
         print("No benchmarks were run.")
 

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -2,51 +2,27 @@ import subprocess
 import json
 import os
 
+INDIVIDUAL_BENCH_TEMPLATE = """
+<details><summary>%s %s</summary>
+  <p>\n\n
+\n\n
+```bash\n
+%s\n\n
+```\n\n
 
-def check_if_benches_should_run():
-    EXPR = '__TRAVIS_RUN_BENCHES='
-    out = subprocess.check_output('git log -n 1', shell=True).decode('utf-8')
-    print(os.environ.get('TRAVIS_COMMIT_MESSAGE', 'NO COMMIT MSG'))
-    print(os.environ.get('TRAVIS_COMMIT', 'NO COMMIT'))
-    print(os.environ.get('TRAVIS_PULL_REQUEST_BRANCH', 'NO COMMIT'))
+</p></details>
+"""
 
-    for line in out.split('\n'):
-        # If the EXPR appears in the line, return the given value
-        try:
-            idx = line.index(EXPR)
-            return int(line[idx + len(EXPR):])
-        except ValueError:
-            continue
+COMPARISON_TEMPLATE = """
+<details><summary>%s %s</summary>
+  <p>\n\n
+\n\n
+```bash\n
+%s\n\n
+```\n\n
 
-    return None
-
-
-def run_warmup():
-    print('=================== Warming up ==============================')
-    for _ in range(3):
-        subprocess.check_output('cargo bench', shell=True)
-
-
-def run_benches():
-    subprocess.call('cargo bench', shell=True)
-
-
-def run_benches_for_n_commits(n_commits):
-    # Store the name of the current branch
-    current_branch_name = subprocess \
-        .check_output('git rev-parse --abbrev-ref HEAD', shell=True) \
-        .decode('utf-8').rstrip()
-
-    os.mkdir('bench_results')
-
-    for k in range(n_commits):
-        print('=================== Benching commit %s ==============================' % k)
-        run_benches()
-        subprocess.call('git checkout HEAD~', shell=True)
-        print('=================== Done ==============================')
-
-    # Go back to the commit handled by the CI
-    subprocess.call('git checkout %s' % current_branch_name, shell=True)
+</p></details>
+"""
 
 
 def get_pull_request_id():
@@ -56,46 +32,127 @@ def get_pull_request_id():
     return int(pr_id)
 
 
-def cd_to_cloned_repo():
-    url = 'git@github.com:lumol-org/lumol.git'
-    subprocess.call('git clone %s cloned_repo' % url)
-    os.chdir('cloned_repo')
-    subprocess.call('git status')
+def request_api(endpoint, data=None):
+    url = 'https://api.github.com/repos/lumol-org/lumol' + endpoint
+    username = os.environ['GITHUB_USER_NAME']
+    token = os.environ['GITHUB_USER_TOKEN']
+
+    cmd = "curl -sS %s  -u '%s:%s'" % (url, username, token)
+    if data is not None:
+        cmd += " --data '%s'" % json.dumps(data)
+
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    return json.loads(out)
 
 
-def comment_pull_request(comment):
+def check_if_benches_should_run():
+    EXPR = '@bot benchmark'
     pr_id = get_pull_request_id()
-    print(pr_id)
-    username = os.environ.get('GITHUB_USER_NAME', None)
-    token = os.environ.get('GITHUB_USER_TOKEN', None)
+    if pr_id is None:
+        print("This is not a PR, the benchmarks are not run.")
+        return None
 
-    if username is None:
-        print('GITHUB_USER_NAME is not set, unable to comment PR.')
+    # Get the text of the PR in `body`
+    out = request_api('/pulls/%s' % pr_id)
 
-    if token is None:
-        print('GITHUB_USER_TOKEN is not set, unable to comment PR.')
+    clone_url = out['head']['repo']['clone_url']
+    body = out['body']
 
+    if EXPR not in body:
+        print('No benchmarks were requested.')
+        return None
+
+    begin = body.index(EXPR)
+    end = len(body)
+    try:
+        s = begin + len(EXPR) + 1
+        end = body[s:].index(' ') + s
+    except ValueError:
+        pass
+
+    n_commits = body[begin + len(EXPR):end]
+
+    return int(n_commits), clone_url
+
+
+def get_commit_descriptions(n_commits):
+    cmd = 'git log --oneline | head -n %s' % n_commits
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    descriptions = []
+    for line in out.split('\n'):
+        if line.rstrip() == '':
+            continue
+        h, _, title = line.partition(' ')
+        descriptions.append((h, title))
+
+    return descriptions
+
+
+def run_warmup():
+    print('=================== Warming up ==============================')
+    for _ in range(3):
+        subprocess.check_output('cargo bench', shell=True)
+
+
+def run_bench(k):
+    # The output files have to be outside of the directory for
+    # us to be able to git checkout.
+    subprocess.call('cargo bench > ../bench_%s.txt' % k, shell=True)
+
+
+def run_benches_for_n_commits(n_commits):
+    for k in range(n_commits):
+        print('=================== Benching commit %s ==============================' % k)
+        run_bench(k)
+        subprocess.call('git checkout HEAD~', shell=True)
+        print('=================== Done ==============================')
+
+
+def cd_to_cloned_repo(url):
+    subprocess.call('git clone %s cloned_repo' % url, shell=True)
+    os.chdir('cloned_repo')
+    subprocess.call('pwd', shell=True)
+    subprocess.call('git checkout %s' % os.environ['TRAVIS_PULL_REQUEST_BRANCH'], shell=True)
+    subprocess.call('git status', shell=True)
+
+
+def comment_pull_request(n_commits):
+    pr_id = get_pull_request_id()
+    descriptions = get_commit_descriptions(n_commits)
+
+    # Comparison benchmarks
+    comment = '## Comparison benchmarks\n (comparisons with %s)' % descriptions[-1][0]
+
+    for k, (h, title) in enumerate(descriptions[:-1]):
+        cmd = 'cargo benchcmp ../bench_%s.txt ../bench_%s' % (n_commits - 1, k)
+        out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+        comment += COMPARISON_TEMPLATE % (h, title, out)
+
+    # Individual benchmarks
+    comment += '\n## Individual benchmarks\n'
+
+    for k, (h, title) in enumerate(descriptions):
+        with open('../bench_%s.txt' % k) as f:
+            bench = f.read()
+        comment += INDIVIDUAL_BENCH_TEMPLATE % (h, title, bench)
+
+    # Emit the request
     data = {
         'body': comment
     }
-    url = 'https://api.github.com/repos/lumol-org/lumol/issues/%s/comments' % pr_id
-    cmd = "curl -i %s --data '%s' -u '%s:%s'" % (url, json.dumps(data), username, token)
-    print("Calling %s" % cmd)
-    subprocess.call(cmd, shell=True)
+    request_api('/issues/%s/comments' % pr_id, data)
 
 
 def main():
-    n_commits = check_if_benches_should_run()
-    if n_commits is not None:
-        if get_pull_request_id() is None:
-            print("This is not a PR, the benchmarks are not ran.")
-        cd_to_cloned_repo()
-        comment_pull_request("Test comment from Travis CI")
-        run_warmup()
-        run_benches_for_n_commits(n_commits)
-        os.chdir('../')
-    else:
-        print("No benchmarks were run.")
+    result = check_if_benches_should_run()
+    if result is None:
+        return
+    n_commits, clone_url = result
+    cd_to_cloned_repo(clone_url)
+    run_warmup()
+    run_benches_for_n_commits(n_commits)
+    comment_pull_request(n_commits)
+    subprocess.call('rm ../bench_*.txt', shell=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here is a draft of how I would like to run the benches on Travis CI.

This ideas behind this are:
* the ability to run the benches or a remote machine is really valuable
* Travis CI may not be the ideal tool for that, but it's the only one we have (right ?)
* most of the times running the benchmarks on Travis is useless since the changes are not performance-related

That's why I suggest something where the benchmarks are only run when the user requests it, and this is done by checking if the expression `__TRAVIS_RUN_BENCHES=n` is present in the commit message. If this is, the benchmarks will be run for the `n` latest commits starting with the one at the end of the branch.


Right now the results of the benches are only displayed on the build log, which is not super useful. I'm trying to think of a way that would make it easy for us to use `cargo benchcmp` on the results, any suggestion is very welcome!