### PR TITLE
Use fixed RNG seeds in benchmarks

### DIFF
--- a/benches/argon.rs
+++ b/benches/argon.rs
@@ -42,7 +42,7 @@ fn cache_move_particle(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(654646);
 
     let particle: usize = rng.gen_range(0, system.size());
     let mut delta = system[particle].position;

--- a/benches/nacl.rs
+++ b/benches/nacl.rs
@@ -78,7 +78,7 @@ fn cache_move_particle_ewald(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(41201154);
 
     let particle: usize = rng.gen_range(0, system.size());
     let mut delta = system[particle].position;
@@ -96,7 +96,7 @@ fn cache_move_particle_wolf(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(474114);
 
     let particle: usize = rng.gen_range(0, system.size());
     let mut delta = system[particle].position;

--- a/benches/propane.rs
+++ b/benches/propane.rs
@@ -42,7 +42,7 @@ fn cache_move_particles(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(84541545);
 
     let molecule = rng.choose(system.molecules()).unwrap();
     let mut delta = vec![];
@@ -61,7 +61,7 @@ fn cache_move_all_rigid_molecules(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(7012121);
     for molecule in system.molecules().to_owned() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
         for i in molecule {

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -2,6 +2,8 @@ use lumol::sys::{System, Trajectory};
 use lumol_input::InteractionsInput;
 use std::path::Path;
 
+use rand::{XorShiftRng, SeedableRng};
+
 pub fn get_system(name: &str) -> System {
     let data = Path::new(file!()).parent().unwrap().join("..").join("data");
 
@@ -14,4 +16,8 @@ pub fn get_system(name: &str) -> System {
                       .unwrap();
 
     system
+}
+
+pub fn get_rng(seed: u32) -> XorShiftRng {
+    XorShiftRng::from_seed([seed, 784, 71255487, 5824])
 }

--- a/benches/water.rs
+++ b/benches/water.rs
@@ -89,7 +89,7 @@ fn cache_move_particles_wolf(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(454548784);
 
     let molecule = rng.choose(system.molecules()).unwrap();
     let mut delta = vec![];
@@ -110,7 +110,7 @@ fn cache_move_particles_ewald(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(9886565);
 
     let molecule = rng.choose(system.molecules()).unwrap();
     let mut delta = vec![];
@@ -131,7 +131,7 @@ fn cache_move_all_rigid_molecules_wolf(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(3);
     for molecule in system.molecules().to_owned() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
         for i in molecule {
@@ -151,7 +151,7 @@ fn cache_move_all_rigid_molecules_ewald(bencher: &mut Bencher) {
     let mut cache = EnergyCache::new();
     cache.init(&system);
 
-    let mut rng = rand::weak_rng();
+    let mut rng = utils::get_rng(2121);
     for molecule in system.molecules().to_owned() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
         for i in molecule {


### PR DESCRIPTION
All is said in the title, this reduces the huge variability of cache benchmarks.