### PR TITLE
Make the System Sync + Send

### DIFF
--- a/benches/nacl.rs
+++ b/benches/nacl.rs
@@ -10,7 +10,7 @@ extern crate lumol_input;
 use bencher::Bencher;
 use rand::Rng;
 
-use lumol::energy::{Ewald, Wolf, GlobalPotential};
+use lumol::energy::{Ewald, SharedEwald, Wolf, GlobalPotential};
 use lumol::sys::EnergyCache;
 use lumol::types::Vector3D;
 
@@ -19,7 +19,7 @@ mod utils;
 
 fn energy_ewald(bencher: &mut Bencher) {
     let system = utils::get_system("nacl");
-    let mut ewald = Ewald::new(9.5, 7);
+    let ewald = SharedEwald::new(Ewald::new(9.5, 7));
 
     bencher.iter(||{
         let _ = ewald.energy(&system);
@@ -28,7 +28,7 @@ fn energy_ewald(bencher: &mut Bencher) {
 
 fn forces_ewald(bencher: &mut Bencher) {
     let system = utils::get_system("nacl");
-    let mut ewald = Ewald::new(9.5, 7);
+    let ewald = SharedEwald::new(Ewald::new(9.5, 7));
 
     bencher.iter(||{
         let _ = ewald.forces(&system);
@@ -37,7 +37,7 @@ fn forces_ewald(bencher: &mut Bencher) {
 
 fn virial_ewald(bencher: &mut Bencher) {
     let system = utils::get_system("nacl");
-    let mut ewald = Ewald::new(9.5, 7);
+    let ewald = SharedEwald::new(Ewald::new(9.5, 7));
 
     bencher.iter(||{
         let _ = ewald.virial(&system);
@@ -46,7 +46,7 @@ fn virial_ewald(bencher: &mut Bencher) {
 
 fn energy_wolf(bencher: &mut Bencher) {
     let system = utils::get_system("nacl");
-    let mut wolf = Wolf::new(12.0);
+    let wolf = Wolf::new(12.0);
 
     bencher.iter(||{
         let _ = wolf.energy(&system);
@@ -55,7 +55,7 @@ fn energy_wolf(bencher: &mut Bencher) {
 
 fn forces_wolf(bencher: &mut Bencher) {
     let system = utils::get_system("nacl");
-    let mut wolf = Wolf::new(12.0);
+    let wolf = Wolf::new(12.0);
 
     bencher.iter(||{
         let _ = wolf.forces(&system);
@@ -64,7 +64,7 @@ fn forces_wolf(bencher: &mut Bencher) {
 
 fn virial_wolf(bencher: &mut Bencher) {
     let system = utils::get_system("nacl");
-    let mut wolf = Wolf::new(12.0);
+    let wolf = Wolf::new(12.0);
 
     bencher.iter(||{
         let _ = wolf.virial(&system);
@@ -73,7 +73,9 @@ fn virial_wolf(bencher: &mut Bencher) {
 
 fn cache_move_particle_ewald(bencher: &mut Bencher) {
     let mut system = utils::get_system("nacl");
-    system.interactions_mut().set_coulomb(Box::new(Ewald::new(9.5, 7)));
+    system.interactions_mut().set_coulomb(
+        Box::new(SharedEwald::new(Ewald::new(9.5, 7)))
+    );
 
     let mut cache = EnergyCache::new();
     cache.init(&system);

--- a/benches/water.rs
+++ b/benches/water.rs
@@ -10,14 +10,14 @@ extern crate lumol_input;
 use bencher::Bencher;
 use rand::Rng;
 
-use lumol::energy::{Ewald, Wolf, PairRestriction, CoulombicPotential, GlobalPotential};
+use lumol::energy::{Ewald, SharedEwald, Wolf, PairRestriction, CoulombicPotential, GlobalPotential};
 use lumol::sys::EnergyCache;
 use lumol::types::Vector3D;
 
 mod utils;
 
-fn get_ewald() -> Ewald {
-    let mut ewald = Ewald::new(8.0, 7);
+fn get_ewald() -> SharedEwald {
+    let mut ewald = SharedEwald::new(Ewald::new(8.0, 7));
     ewald.set_restriction(PairRestriction::InterMolecular);
     ewald
 }
@@ -30,7 +30,7 @@ fn get_wolf() -> Wolf {
 
 fn energy_ewald(bencher: &mut Bencher) {
     let system = utils::get_system("water");
-    let mut ewald = get_ewald();
+    let ewald = get_ewald();
 
     bencher.iter(||{
         let _ = ewald.energy(&system);
@@ -39,7 +39,7 @@ fn energy_ewald(bencher: &mut Bencher) {
 
 fn forces_ewald(bencher: &mut Bencher) {
     let system = utils::get_system("water");
-    let mut ewald = get_ewald();
+    let ewald = get_ewald();
 
     bencher.iter(||{
         let _ = ewald.forces(&system);
@@ -48,7 +48,7 @@ fn forces_ewald(bencher: &mut Bencher) {
 
 fn virial_ewald(bencher: &mut Bencher) {
     let system = utils::get_system("water");
-    let mut ewald = get_ewald();
+    let ewald = get_ewald();
 
     bencher.iter(||{
         let _ = ewald.virial(&system);
@@ -57,7 +57,7 @@ fn virial_ewald(bencher: &mut Bencher) {
 
 fn energy_wolf(bencher: &mut Bencher) {
     let system = utils::get_system("water");
-    let mut wolf = get_wolf();
+    let wolf = get_wolf();
 
     bencher.iter(||{
         let _ = wolf.energy(&system);
@@ -66,7 +66,7 @@ fn energy_wolf(bencher: &mut Bencher) {
 
 fn forces_wolf(bencher: &mut Bencher) {
     let system = utils::get_system("water");
-    let mut wolf = get_wolf();
+    let wolf = get_wolf();
 
     bencher.iter(||{
         let _ = wolf.forces(&system);
@@ -75,7 +75,7 @@ fn forces_wolf(bencher: &mut Bencher) {
 
 fn virial_wolf(bencher: &mut Bencher) {
     let system = utils::get_system("water");
-    let mut wolf = get_wolf();
+    let wolf = get_wolf();
 
     bencher.iter(||{
         let _ = wolf.virial(&system);

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -7,7 +7,9 @@ use lumol::Logger;
 use lumol::sys::{UnitCell, System, Trajectory};
 use lumol::units;
 use lumol::sim::Simulation;
-use lumol::energy::{LennardJones, PairInteraction, PairRestriction, NullPotential, Ewald};
+use lumol::energy::{PairInteraction, PairRestriction};
+use lumol::energy::{LennardJones, NullPotential};
+use lumol::energy::{Ewald, SharedEwald};
 use lumol::sim::mc::{MonteCarlo, Translate, Rotate, Resize};
 use lumol::out::{EnergyOutput, PropertiesOutput, TrajectoryOutput};
 
@@ -56,7 +58,7 @@ fn get_system() -> System {
 
     // Add ewald summation method.
     let ewald = Ewald::new(6.0, 7);
-    system.interactions_mut().set_coulomb(Box::new(ewald));
+    system.interactions_mut().set_coulomb(Box::new(SharedEwald::new(ewald)));
 
     // Check if bonds are guessed correctly.
     assert_eq!(system.size() as f64 / system.molecules().len() as f64, 3.0);

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -114,7 +114,7 @@ impl Wolf {
 }
 
 impl GlobalCache for Wolf {
-    fn move_particles_cost(&mut self, system: &System, idxes: &[usize], newpos: &[Vector3D]) -> f64 {
+    fn move_particles_cost(&self, system: &System, idxes: &[usize], newpos: &[Vector3D]) -> f64 {
         let mut e_old = 0.0;
         let mut e_new = 0.0;
 
@@ -160,7 +160,7 @@ impl GlobalCache for Wolf {
         return e_new - e_old;
     }
 
-    fn update(&mut self) {
+    fn update(&self) {
         // Nothing to do
     }
 }
@@ -170,7 +170,7 @@ impl GlobalPotential for Wolf {
         Some(self.cutoff)
     }
 
-    fn energy(&mut self, system: &System) -> f64 {
+    fn energy(&self, system: &System) -> f64 {
         let natoms = system.size();
         let mut res = 0.0;
         for i in 0..natoms {
@@ -192,7 +192,7 @@ impl GlobalPotential for Wolf {
         return res;
     }
 
-    fn forces(&mut self, system: &System) -> Vec<Vector3D> {
+    fn forces(&self, system: &System) -> Vec<Vector3D> {
         let natoms = system.size();
         let mut res = vec![Vector3D::zero(); natoms];
         for i in 0..natoms {
@@ -214,7 +214,7 @@ impl GlobalPotential for Wolf {
         return res;
     }
 
-    fn virial(&mut self, system: &System) -> Matrix3 {
+    fn virial(&self, system: &System) -> Matrix3 {
         let natoms = system.size();
         let mut res = Matrix3::zero();
         for i in 0..natoms {
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn energy() {
         let system = testing_system();
-        let mut wolf = Wolf::new(8.0);
+        let wolf = Wolf::new(8.0);
 
         let e = wolf.energy(&system);
         // Wolf is not very good for heterogeneous systems
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn forces() {
         let mut system = testing_system();
-        let mut wolf = Wolf::new(8.0);
+        let wolf = Wolf::new(8.0);
 
         let forces = wolf.forces(&system);
         let norm = (forces[0] + forces[1]).norm();

--- a/src/core/src/energy/mod.rs
+++ b/src/core/src/energy/mod.rs
@@ -251,7 +251,7 @@ pub use self::restrictions::{PairRestriction, RestrictionInfo};
 
 mod global;
 pub use self::global::{GlobalPotential, GlobalCache, CoulombicPotential};
-pub use self::global::{Wolf, Ewald};
+pub use self::global::{Wolf, Ewald, SharedEwald};
 
 mod pairs;
 pub use self::pairs::PairInteraction;

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -14,7 +14,7 @@ use types::{Vector3D, Array2};
 
 /// Callback for updating a cache. It also take an `&mut System` argument for
 /// updating the cache inside the global potentials.
-type UpdateCallback = Box<Fn(&mut EnergyCache, &mut System)>;
+type UpdateCallback = Box<Fn(&mut EnergyCache, &mut System) + Send + Sync>;
 
 /// This is a cache for energy computation.
 ///

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -220,14 +220,14 @@ impl EnergyCache {
         }
 
         let coulomb_delta = if let Some(coulomb) = system.interactions().coulomb() {
-            coulomb.borrow_mut().move_particles_cost(system, &idxes, newpos)
+            coulomb.move_particles_cost(system, &idxes, newpos)
         } else {
             0.0
         };
 
         let mut global_delta = 0.0;
-        for potential in system.interactions().globals() {
-            global_delta += potential.borrow_mut().move_particles_cost(system, &idxes, newpos);
+        for global in system.interactions().globals() {
+            global_delta += global.move_particles_cost(system, &idxes, newpos);
         }
 
         let pairs_tail = evaluator.pairs_tail();
@@ -266,10 +266,11 @@ impl EnergyCache {
 
             // Update the cache for the global potentials
             if let Some(coulomb) = system.interactions().coulomb() {
-                coulomb.borrow_mut().update();
+                coulomb.update();
             }
-            for potential in system.interactions().globals() {
-                potential.borrow_mut().update();
+
+            for global in system.interactions().globals() {
+                global.update();
             }
         }));
         return cost;

--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -82,7 +82,7 @@ impl Compute for Forces {
         }
 
         if let Some(coulomb) = system.interactions().coulomb() {
-            let forces = coulomb.borrow_mut().forces(system);
+            let forces = coulomb.forces(system);
             debug_assert_eq!(forces.len(), natoms, "Wrong `forces` size in coulomb potentials");
             for (i, force) in forces.iter().enumerate() {
                 res[i] += force;
@@ -90,7 +90,7 @@ impl Compute for Forces {
         }
 
         for global in system.interactions().globals() {
-            let forces = global.borrow_mut().forces(system);
+            let forces = global.forces(system);
             debug_assert_eq!(forces.len(), natoms, "Wrong `forces` size in global potentials");
             for (i, force) in forces.iter().enumerate() {
                 res[i] += force;
@@ -210,11 +210,11 @@ impl Compute for Virial {
         // (angles & dihedrals)
 
         if let Some(coulomb) = system.interactions().coulomb() {
-            virial += coulomb.borrow_mut().virial(system);
+            virial += coulomb.virial(system);
         }
 
         for global in system.interactions().globals() {
-            virial += global.borrow_mut().virial(system);
+            virial += global.virial(system);
         }
 
         return virial;

--- a/src/core/src/sys/energy.rs
+++ b/src/core/src/sys/energy.rs
@@ -147,7 +147,7 @@ impl<'a> EnergyEvaluator<'a> {
     #[inline]
     pub fn coulomb(&self) -> f64 {
         if let Some(coulomb) = self.system.interactions().coulomb() {
-            coulomb.borrow_mut().energy(self.system)
+            coulomb.energy(self.system)
         } else {
             0.0
         }
@@ -158,7 +158,7 @@ impl<'a> EnergyEvaluator<'a> {
     pub fn global(&self) -> f64 {
         let mut energy = 0.0;
         for global in self.system.interactions().globals() {
-            energy += global.borrow_mut().energy(self.system);
+            energy += global.energy(self.system);
         }
         return energy;
     }

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -6,7 +6,6 @@
 
 use std::collections::BTreeMap;
 use std::cmp::{min, max};
-use std::cell::RefCell;
 
 use energy::{PairInteraction, BondPotential, AnglePotential, DihedralPotential};
 use energy::{GlobalPotential, CoulombicPotential};
@@ -104,9 +103,9 @@ pub struct Interactions {
     /// Dihedral angles potentials
     dihedrals: BTreeMap<DihedralKind, Vec<Box<DihedralPotential>>>,
     /// Coulombic potential solver
-    coulomb: Option<RefCell<Box<CoulombicPotential>>>,
+    coulomb: Option<Box<CoulombicPotential>>,
     /// Global potentials
-    globals: Vec<RefCell<Box<GlobalPotential>>>,
+    globals: Vec<Box<GlobalPotential>>,
     /// Particles names <=> kind associations
     kinds: ParticleKinds,
 }
@@ -176,12 +175,12 @@ impl Interactions {
 
     /// Set the coulombic interaction for all pairs to `potential`
     pub fn set_coulomb(&mut self, potential: Box<CoulombicPotential>) {
-        self.coulomb = Some(RefCell::new(potential));
+        self.coulomb = Some(potential);
     }
 
     /// Add the `potential` global interaction
     pub fn add_global(&mut self, potential: Box<GlobalPotential>) {
-        self.globals.push(RefCell::new(potential));
+        self.globals.push(potential);
     }
 }
 
@@ -266,15 +265,13 @@ impl Interactions {
         }
     }
 
-    /// Get the coulombic interaction as a `RefCell`, because the
-    /// `GlobalPotential` are allowed to mutate themselves when computing
-    /// energy.
-    pub fn coulomb(&self) -> Option<&RefCell<Box<CoulombicPotential>>> {
+    /// Get the coulombic interaction
+    pub fn coulomb(&self) -> Option<&Box<CoulombicPotential>> {
         self.coulomb.as_ref()
     }
 
     /// Get all global interactions
-    pub fn globals(&self) -> &[RefCell<Box<GlobalPotential>>] {
+    pub fn globals(&self) -> &[Box<GlobalPotential>] {
         &self.globals
     }
 }

--- a/src/input/src/interactions/coulomb.rs
+++ b/src/input/src/interactions/coulomb.rs
@@ -3,7 +3,7 @@
 use toml::Value;
 
 use lumol::sys::System;
-use lumol::energy::{Wolf, Ewald, CoulombicPotential};
+use lumol::energy::{Wolf, Ewald, SharedEwald, CoulombicPotential};
 
 use error::{Error, Result};
 use FromToml;
@@ -39,7 +39,10 @@ impl InteractionsInput {
         if let Value::Table(ref table) = coulomb[key] {
             let mut potential: Box<CoulombicPotential> = match key {
                 "wolf" => Box::new(try!(Wolf::from_toml(table))),
-                "ewald" => Box::new(try!(Ewald::from_toml(table))),
+                "ewald" => {
+                    let ewald = try!(Ewald::from_toml(table));
+                    Box::new(SharedEwald::new(ewald))
+                }
                 other => {
                     return Err(Error::from(format!("Unknown coulomb solver '{}'", other)))
                 },

--- a/tests/nist-spce.rs
+++ b/tests/nist-spce.rs
@@ -11,7 +11,7 @@ extern crate lumol_input as input;
 use lumol::sys::{System, UnitCell};
 use lumol::sys::Trajectory;
 use lumol::energy::{PairInteraction, LennardJones, NullPotential};
-use lumol::energy::{Ewald, PairRestriction, CoulombicPotential};
+use lumol::energy::{Ewald, SharedEwald, PairRestriction, CoulombicPotential};
 use lumol::consts::K_BOLTZMANN;
 
 use std::path::Path;
@@ -72,8 +72,9 @@ pub fn get_system(path: &str, cutoff: f64) -> System {
     );
 
     let mut ewald = Ewald::new(cutoff, 5);
-    ewald.set_restriction(PairRestriction::InterMolecular);
     ewald.set_alpha(5.6 / f64::min(f64::min(a, b), c));
+    let mut ewald = SharedEwald::new(ewald);
+    ewald.set_restriction(PairRestriction::InterMolecular);
     system.interactions_mut().set_coulomb(Box::new(ewald));
 
     return system;


### PR DESCRIPTION
To make the System `Send + Sync` I applied the following changes:

1. the `GlobalPotential` trait now require `Send + Sync`;
2. methods of both `GlobalPotential` and `GlobalCache` take self by non-mutable reference;

This means that the System no longer has special knowledge of the global potentials and the RefCell are gone in Interactions.

This also means that we can not implement `CoulombicPotential` for Ewald right away, but we need to go through `struct SharedEwald(RwLock<Ewald>)` to get both interior mutability and Send + Sync.

@antoinewdg, in #131 you used `Arc<Mutex<_>>` for this, why the `Arc`?