### PR TITLE
Add function to get cutoff radius for global potentials.

### DIFF
--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -704,6 +704,10 @@ impl Ewald {
 }
 
 impl GlobalPotential for Ewald {
+    fn get_cutoff(&self) -> Option<f64> {
+        Some(self.rc)
+    }
+
     fn energy(&mut self, system: &System) -> f64 {
         self.precompute(system.cell());
         let real = self.real_space_energy(system);

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -704,7 +704,7 @@ impl Ewald {
 }
 
 impl GlobalPotential for Ewald {
-    fn get_cutoff(&self) -> Option<f64> {
+    fn cutoff(&self) -> Option<f64> {
         Some(self.rc)
     }
 

--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -39,6 +39,10 @@ use energy::PairRestriction;
 /// }
 ///
 /// impl GlobalPotential for ShiftAll {
+///     fn get_cutoff(&self) -> Option<f64> {
+///         None
+///     }
+///
 ///     fn energy(&mut self, system: &System) -> f64 {
 ///         // shift all particles by delta
 ///         self.delta * system.size() as f64
@@ -84,6 +88,8 @@ use energy::PairRestriction;
 /// assert_eq!(system.virial(), Matrix3::zero());
 /// ```
 pub trait GlobalPotential: GlobalCache + BoxCloneGlobal {
+    /// Return the cut off radius.
+    fn get_cutoff(&self) -> Option<f64>;
     /// Compute the energetic contribution of this potential
     fn energy(&mut self, system: &System) -> f64;
     /// Compute the force contribution of this potential. This function should
@@ -120,6 +126,10 @@ impl_box_clone!(GlobalPotential, BoxCloneGlobal, box_clone_gobal);
 /// }
 ///
 /// impl GlobalPotential for ShiftAll {
+///     fn get_cutoff(&self) -> Option<f64> {
+///         None
+///     }
+///
 ///     fn energy(&mut self, system: &System) -> f64 {
 ///         // shift all particles by delta
 ///         self.delta * system.size() as f64

--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -39,7 +39,7 @@ use energy::PairRestriction;
 /// }
 ///
 /// impl GlobalPotential for ShiftAll {
-///     fn get_cutoff(&self) -> Option<f64> {
+///     fn cutoff(&self) -> Option<f64> {
 ///         None
 ///     }
 ///
@@ -89,7 +89,7 @@ use energy::PairRestriction;
 /// ```
 pub trait GlobalPotential: GlobalCache + BoxCloneGlobal {
     /// Return the cut off radius.
-    fn get_cutoff(&self) -> Option<f64>;
+    fn cutoff(&self) -> Option<f64>;
     /// Compute the energetic contribution of this potential
     fn energy(&mut self, system: &System) -> f64;
     /// Compute the force contribution of this potential. This function should
@@ -126,7 +126,7 @@ impl_box_clone!(GlobalPotential, BoxCloneGlobal, box_clone_gobal);
 /// }
 ///
 /// impl GlobalPotential for ShiftAll {
-///     fn get_cutoff(&self) -> Option<f64> {
+///     fn cutoff(&self) -> Option<f64> {
 ///         None
 ///     }
 ///

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -166,6 +166,10 @@ impl GlobalCache for Wolf {
 }
 
 impl GlobalPotential for Wolf {
+    fn get_cutoff(&self) -> Option<f64> {
+        Some(self.cutoff)
+    }
+
     fn energy(&mut self, system: &System) -> f64 {
         let natoms = system.size();
         let mut res = 0.0;

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -166,7 +166,7 @@ impl GlobalCache for Wolf {
 }
 
 impl GlobalPotential for Wolf {
-    fn get_cutoff(&self) -> Option<f64> {
+    fn cutoff(&self) -> Option<f64> {
         Some(self.cutoff)
     }
 

--- a/src/core/src/energy/pairs.rs
+++ b/src/core/src/energy/pairs.rs
@@ -158,10 +158,10 @@ impl PairInteraction {
     ///
     /// let ar = LennardJones{sigma: 3.405, epsilon: 1.0};
     /// let interaction = PairInteraction::new(Box::new(ar), 9.1935);
-    /// let rc = interaction.get_cutoff();
+    /// let rc = interaction.cutoff();
     /// assert_eq!(rc, 2.7f64 * 3.405);
     /// ```
-    pub fn get_cutoff(&self) -> f64 {
+    pub fn cutoff(&self) -> f64 {
         self.cutoff
     }
 }
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn cutoff() {
+    fn test_cutoff() {
         let lj = LennardJones{sigma: 1.0, epsilon: 2.0};
         let pairs = PairInteraction::new(Box::new(lj), 4.0);
 
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!(pairs.force(4.1), 0.0);
         assert_eq!(pairs.energy(4.1), 0.0);
 
-        assert_eq!(pairs.get_cutoff(), 4.0);
+        assert_eq!(pairs.cutoff(), 4.0);
     }
 
     #[test]

--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -58,7 +58,7 @@ impl MCMove for Resize {
         self.rc_max = system.interactions()
                             .all_pairs()
                             .iter()
-                            .map(|i| i.get_cutoff())
+                            .map(|i| i.cutoff())
                             .fold(f64::NAN, f64::max)
     }
 

--- a/src/core/src/sim/mc/moves/translate.rs
+++ b/src/core/src/sim/mc/moves/translate.rs
@@ -73,7 +73,7 @@ impl MCMove for Translate {
         self.dr_max = system.interactions()
                             .all_pairs()
                             .iter()
-                            .map(|i| i.get_cutoff())
+                            .map(|i| i.cutoff())
                             .fold(f64::NAN, f64::max);
         if self.dr > self.dr_max {
             self.dr = self.dr_max


### PR DESCRIPTION
This PR adds a function to `GlobalPotentials`, that returns their `cutoff`.
In contrast to `PairPotentials`, `GlobalPotentials` may not have a cutoff so that the function returns an `Option`.