### PR TITLE
Npt MC check global cutoff in setup function.

### DIFF
--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -54,12 +54,23 @@ impl MCMove for Resize {
 
         // Get the largest cutoff of all intermolecular interactions in the
         // system.
-        // TODO: include electrostatic interactions
-        self.rc_max = system.interactions()
+
+        // Go through global interactions
+        let rc_glob = system.interactions()
+                            .globals()
+                            .iter()
+                            .map(|i| i.cutoff())
+                            .filter_map(|rc| rc)
+                            .fold(f64::NAN, f64::max);
+
+        // Pair interactions
+        let rc_pairs = system.interactions()
                             .all_pairs()
                             .iter()
                             .map(|i| i.cutoff())
-                            .fold(f64::NAN, f64::max)
+                            .fold(f64::NAN, f64::max);
+
+        self.rc_max = f64::max(rc_glob, rc_pairs)
     }
 
     fn prepare(&mut self, system: &mut System, rng: &mut Box<Rng>) -> bool {

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -315,7 +315,6 @@ impl Interactions {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::f64;
 
     use energy::{Harmonic, Wolf, Ewald, SharedEwald, LennardJones, PairInteraction};
     use sys::ParticleKind as Kind;

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -280,7 +280,9 @@ impl Interactions {
 #[cfg(test)]
 mod test {
     use super::*;
-    use energy::{Harmonic, Wolf, PairInteraction};
+    use std::f64;
+
+    use energy::{Harmonic, Wolf, Ewald, SharedEwald, PairInteraction};
     use sys::ParticleKind as Kind;
 
     #[test]
@@ -442,5 +444,18 @@ mod test {
         let mut interactions = Interactions::new();
         interactions.add_global(Box::new(Wolf::new(1.0)));
         assert_eq!(interactions.globals().len(), 1);
+    }
+
+    #[test]
+    fn test_globals_cutoff() {
+        let mut interactions = Interactions::new();
+        interactions.add_global(Box::new(Wolf::new(1.0)));
+        interactions.add_global(Box::new(SharedEwald::new(Ewald::new(5.0, 5))));
+        let rc_glob = interactions.globals()
+            .iter()
+            .map(|i| i.cutoff())
+            .filter_map(|rc| rc)
+            .fold(f64::NAN, f64::max);
+        assert_eq!(rc_glob, 5.0)
     }
 }


### PR DESCRIPTION
Adds checking of cutoffs (If present) from `GlobalPotential` within `setup` in the `Resize` MC move.