### PR TITLE
Run benchmarks locally for a PR

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
 click
 py-cpuinfo
+requests

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+click
+py-cpuinfo

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -1,0 +1,185 @@
+import subprocess
+import json
+import os
+import re
+
+import click
+import cpuinfo
+
+BASE_REPO_URL = 'https://github.com/lumol-org/lumol.git'
+
+INDIVIDUAL_BENCH_TEMPLATE = """
+<details><summary>%s %s</summary>
+  <p>\n\n
+\n\n
+```bash\n
+%s\n\n
+```\n\n
+
+</p></details>
+"""
+
+COMPARISON_TEMPLATE = """
+<details><summary>%s %s</summary>
+  <p>\n\n
+\n\n
+```bash\n
+%s\n\n
+```\n\n
+
+</p></details>
+"""
+
+
+def request_api(endpoint, data=None):
+    url = 'https://api.github.com/repos/lumol-org/lumol' + endpoint
+    username = os.environ['LUMOL_GH_USERNAME']
+    token = os.environ['LUMOL_GH_TOKEN']
+
+    cmd = "curl -sS %s  -u '%s:%s'" % (url, username, token)
+    if data is not None:
+        cmd += " --data '%s'" % json.dumps(data)
+
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    return json.loads(out)
+
+
+def get_master_commit():
+    cmd = 'git log --oneline upstream/master -n 1'
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    h, _, title = out.rstrip().partition(' ')
+    return h, title
+
+
+def get_commit_descriptions(n_commits):
+    """
+    Get hash and title of the `n_commits` latest commits on the branch.
+
+    Also adds the commit at the HEAD of master in the end. If this
+    commit is met earlier, stops at this commit (the master commit
+    is guaranteed to be at the end of the result.
+
+    :param n_commits:
+    :return:
+    """
+    cmd = 'git log --oneline | head -n %s' % n_commits
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    master_h, master_title = get_master_commit()
+
+    descriptions = []
+    for line in out.split('\n'):
+        if line.rstrip() == '':
+            continue
+        h, _, title = line.partition(' ')
+        descriptions.append((h, title))
+        if h == master_h:
+            break
+
+    if descriptions[-1][0] != master_h:
+        descriptions.append((master_h, master_title))
+
+    return descriptions
+
+
+def setup_cloned_repo(pr_id):
+    response = request_api('/pulls/%s' % pr_id)
+    clone_url = response['head']['repo']['clone_url']
+    commit_id = response['head']['sha']
+
+    subprocess.call('git clone %s cloned_repo' % clone_url, shell=True)
+    os.chdir('cloned_repo')
+    subprocess.call('git checkout %s' % commit_id, shell=True)
+    subprocess.call('git remote add upstream %s' % BASE_REPO_URL, shell=True)
+    subprocess.call('git fetch upstream master', shell=True)
+
+
+class Benchmarker:
+    def __init__(self, n_commits, output_dir):
+        self.commit_descriptions = get_commit_descriptions(n_commits)
+        self.output_dir = os.path.abspath(os.path.expanduser(output_dir))
+
+    def run_warmup(self):
+        print('=================== Warming up ==============================')
+        for _ in range(3):
+            subprocess.check_output('cargo bench', shell=True)
+
+    def run_bench(self, h):
+        cmd = 'cargo bench > %s/%s.txt' % (self.output_dir, h)
+        subprocess.call(cmd, shell=True)
+
+    def run_all_benches(self):
+        for h, title in self.commit_descriptions:
+            print('=================== Benching commit %s ==============================' % h)
+            subprocess.call('git checkout %s' % h, shell=True)
+            self.run_bench(h)
+            print('=================== Done ==============================')
+
+    def compare_benches(self):
+        comparisons = {}
+        master_h, _ = self.commit_descriptions[-1]
+        for h, title in self.commit_descriptions[:-1]:
+            cmd = 'cargo benchcmp %s/%s.txt %s/%s.txt --threshold 2 --variance' % (
+                self.output_dir, master_h, self.output_dir, h
+            )
+            out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+            comparisons[h] = out
+
+        return comparisons
+
+    def comment_pr(self, pr_id):
+        # Comparison benchmarks
+        master_h, master_title = self.commit_descriptions[-1]
+        comment = '## Comparing to master (%s)\nusing `--threshold 2, latest commit first`' % master_h
+
+        comparisons = self.compare_benches()
+        for h, title in self.commit_descriptions[:-1]:
+            compare = comparisons[h]
+            comment += COMPARISON_TEMPLATE % (h, title, compare)
+
+        # Individual benchmarks
+        comment += '\n## Individual benchmarks\n'
+
+        for k, (h, title) in enumerate(self.commit_descriptions):
+            with open('%s/%s.txt' % (self.output_dir, h)) as f:
+                bench = f.read()
+            comment += INDIVIDUAL_BENCH_TEMPLATE % (h, title, bench)
+
+        info = cpuinfo.get_cpu_info()
+        if info is not None:
+            comment += '\n<br>**CPU**: %s' % info['brand']
+
+        # Emit the request
+        data = {
+            'body': comment
+        }
+        request_api('/issues/%s/comments' % pr_id, data)
+
+
+@click.command()
+@click.argument('output_dir')
+@click.argument('n_commits', type=click.INT)
+@click.argument('pr_id', type=click.INT)
+def main(output_dir, n_commits, pr_id):
+    """
+    Run the benchmarks for multiple commits on a PR and compare to master.
+
+    The benchmark results are saved in OUTPUT_DIR, and a comment
+    with a summary will be automatically added to the PR.
+    This script requires the environment variables LUMOL_GH_USERNAME
+    and LUMOL_GH_TOKEN to contain respectively the Github username
+    and a personal access token.
+    """
+
+    setup_cloned_repo(pr_id)
+
+    benchmarker = Benchmarker(n_commits, output_dir)
+    benchmarker.run_warmup()
+    benchmarker.run_all_benches()
+
+    benchmarker.comment_pr(pr_id)
+    os.chdir('..')
+    subprocess.call('rm -rf cloned_repo', shell=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -1,54 +1,70 @@
 import subprocess
-import json
 import os
-import re
 
 import click
 import cpuinfo
+import requests
 
 BASE_REPO_URL = 'https://github.com/lumol-org/lumol.git'
 
 INDIVIDUAL_BENCH_TEMPLATE = """
-<details><summary>%s %s</summary>
+<details><summary>{sha} {title}</summary>
   <p>\n\n
 \n\n
 ```bash\n
-%s\n\n
+{body}\n\n
 ```\n\n
 
 </p></details>
 """
 
 COMPARISON_TEMPLATE = """
-<details><summary>%s %s</summary>
+<details><summary>{sha} {title}</summary>
   <p>\n\n
 \n\n
 ```bash\n
-%s\n\n
+{body}\n\n
 ```\n\n
 
 </p></details>
 """
 
 
+def _get_environment_variable(name):
+    var = os.environ.get(name, None)
+    if var is None:
+        msg = 'The environment variable {} must be set to access Github API'.format(name)
+        raise Exception(msg)
+
+    return var
+
+
+def check_for_cargo_benchcmp():
+    try:
+        subprocess.check_output('cargo benchcmp --help', shell=True)
+    except subprocess.CalledProcessError as e:
+        raise Exception("cargo-benchcmp is not installed, please install with "
+                        "`cargo install cargo-benchcmp`")
+
+
 def request_api(endpoint, data=None):
     url = 'https://api.github.com/repos/lumol-org/lumol' + endpoint
-    username = os.environ['LUMOL_GH_USERNAME']
-    token = os.environ['LUMOL_GH_TOKEN']
+    username = _get_environment_variable('LUMOL_GH_USERNAME')
+    token = _get_environment_variable('LUMOL_GH_TOKEN')
 
-    cmd = "curl -sS %s  -u '%s:%s'" % (url, username, token)
-    if data is not None:
-        cmd += " --data '%s'" % json.dumps(data)
+    if data is None:
+        r = requests.get(url, auth=(username, token))
+    else:
+        r = requests.post(url, auth=(username, token), json=data)
 
-    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
-    return json.loads(out)
+    return r.json()
 
 
 def get_master_commit():
     cmd = 'git log --oneline upstream/master -n 1'
     out = subprocess.check_output(cmd, shell=True).decode('utf-8')
-    h, _, title = out.rstrip().partition(' ')
-    return h, title
+    sha, _, title = out.rstrip().partition(' ')
+    return sha, title
 
 
 def get_commit_descriptions(n_commits):
@@ -62,35 +78,36 @@ def get_commit_descriptions(n_commits):
     :param n_commits:
     :return:
     """
-    cmd = 'git log --oneline | head -n %s' % n_commits
+    cmd = 'git log --oneline  -n {}'.format(n_commits)
     out = subprocess.check_output(cmd, shell=True).decode('utf-8')
-    master_h, master_title = get_master_commit()
+    master_sha, master_title = get_master_commit()
 
     descriptions = []
     for line in out.split('\n'):
         if line.rstrip() == '':
             continue
-        h, _, title = line.partition(' ')
-        descriptions.append((h, title))
-        if h == master_h:
+        sha, _, title = line.partition(' ')
+        descriptions.append((sha, title))
+        if sha == master_sha:
             break
 
-    if descriptions[-1][0] != master_h:
-        descriptions.append((master_h, master_title))
+    if descriptions[-1][0] != master_sha:
+        descriptions.append((master_sha, master_title))
 
     return descriptions
 
 
-def setup_cloned_repo(pr_id):
-    response = request_api('/pulls/%s' % pr_id)
-    clone_url = response['head']['repo']['clone_url']
-    commit_id = response['head']['sha']
+def clean_repo():
+    subprocess.call('git checkout master', shell=True)
+    subprocess.call('git branch -D _bot_pr', shell=True)
+    subprocess.call('git remote remove _bot_remote', shell=True)
 
-    subprocess.call('git clone %s cloned_repo' % clone_url, shell=True)
-    os.chdir('cloned_repo')
-    subprocess.call('git checkout %s' % commit_id, shell=True)
-    subprocess.call('git remote add upstream %s' % BASE_REPO_URL, shell=True)
-    subprocess.call('git fetch upstream master', shell=True)
+
+def setup_repo(pr_id):
+    clean_repo()
+    subprocess.call('git remote add _bot_remote {}'.format(BASE_REPO_URL), shell=True)
+    subprocess.call('git fetch _bot_remote pull/{}/head:_bot_pr'.format(pr_id), shell=True)
+    subprocess.call('git checkout _bot_pr', shell=True)
 
 
 class Benchmarker:
@@ -103,56 +120,55 @@ class Benchmarker:
         for _ in range(3):
             subprocess.check_output('cargo bench', shell=True)
 
-    def run_bench(self, h):
-        cmd = 'cargo bench > %s/%s.txt' % (self.output_dir, h)
+    def run_bench(self, sha):
+        cmd = 'cargo bench > {}/{}.txt'.format(self.output_dir, sha)
         subprocess.call(cmd, shell=True)
 
     def run_all_benches(self):
-        for h, title in self.commit_descriptions:
-            print('=================== Benching commit %s ==============================' % h)
-            subprocess.call('git checkout %s' % h, shell=True)
-            self.run_bench(h)
+        for sha, title in self.commit_descriptions:
+            print('=================== Benchmarking commit {} =============================='.format(sha))
+            subprocess.call('git checkout {}'.format(sha), shell=True)
+            self.run_bench(sha)
             print('=================== Done ==============================')
 
     def compare_benches(self):
         comparisons = {}
-        master_h, _ = self.commit_descriptions[-1]
-        for h, title in self.commit_descriptions[:-1]:
-            cmd = 'cargo benchcmp %s/%s.txt %s/%s.txt --threshold 2 --variance' % (
-                self.output_dir, master_h, self.output_dir, h
-            )
+        master_sha, _ = self.commit_descriptions[-1]
+        for sha, title in self.commit_descriptions[:-1]:
+            cmd = 'cargo benchcmp {dir}/{sha_1}.txt {dir}/{sha_2}.txt --threshold 2 --variance' \
+                .format(dir=self.output_dir, sha_1=master_sha, sha_2=sha)
             out = subprocess.check_output(cmd, shell=True).decode('utf-8')
-            comparisons[h] = out
+            comparisons[sha] = out
 
         return comparisons
 
     def comment_pr(self, pr_id):
         # Comparison benchmarks
-        master_h, master_title = self.commit_descriptions[-1]
-        comment = '## Comparing to master (%s)\nusing `--threshold 2, latest commit first`' % master_h
+        master_sha, master_title = self.commit_descriptions[-1]
+        comment = '## Comparing to master ({})\nusing `--threshold 2, latest commit first`'.format(master_sha)
 
         comparisons = self.compare_benches()
-        for h, title in self.commit_descriptions[:-1]:
-            compare = comparisons[h]
-            comment += COMPARISON_TEMPLATE % (h, title, compare)
+        for sha, title in self.commit_descriptions[:-1]:
+            compare = comparisons[sha]
+            comment += COMPARISON_TEMPLATE.format(sha=sha, title=title, body=compare)
 
         # Individual benchmarks
         comment += '\n## Individual benchmarks\n'
 
-        for k, (h, title) in enumerate(self.commit_descriptions):
-            with open('%s/%s.txt' % (self.output_dir, h)) as f:
+        for k, (sha, title) in enumerate(self.commit_descriptions):
+            with open('{}/{}.txt'.format(self.output_dir, sha)) as f:
                 bench = f.read()
-            comment += INDIVIDUAL_BENCH_TEMPLATE % (h, title, bench)
+            comment += INDIVIDUAL_BENCH_TEMPLATE.format(sha=sha, title=title, body=bench)
 
         info = cpuinfo.get_cpu_info()
         if info is not None:
-            comment += '\n<br>**CPU**: %s' % info['brand']
+            comment += '\n<br>**CPU**: {}'.format(info['brand'])
 
         # Emit the request
         data = {
             'body': comment
         }
-        request_api('/issues/%s/comments' % pr_id, data)
+        request_api('/issues/{}/comments'.format(pr_id), data)
 
 
 @click.command()
@@ -169,16 +185,15 @@ def main(output_dir, n_commits, pr_id):
     and LUMOL_GH_TOKEN to contain respectively the Github username
     and a personal access token.
     """
-
-    setup_cloned_repo(pr_id)
+    check_for_cargo_benchcmp()
+    setup_repo(pr_id)
 
     benchmarker = Benchmarker(n_commits, output_dir)
     benchmarker.run_warmup()
     benchmarker.run_all_benches()
-
     benchmarker.comment_pr(pr_id)
-    os.chdir('..')
-    subprocess.call('rm -rf cloned_repo', shell=True)
+
+    clean_repo()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces a script that runs the benchmarks for a PR.

```
$ python scripts/run-benchmarks.py --help
Usage: run-benchmarks.py [OPTIONS] OUTPUT_DIR N_COMMITS PR_ID

  Run the benchmarks for multiple commits on a PR and compare to master.

  The benchmark results are saved in OUTPUT_DIR, and a comment with a
  summary will be automatically added to the PR. This script requires the
  environment variables LUMOL_GH_USERNAME and LUMOL_GH_TOKEN to contain
  respectively the Github username and a personal access token.

Options:
  --help  Show this message and exit.

```


After spending far too much time trying to design a script for this, I went with minimal functionality of running the benchmarks for a specific PR, for a specific number of commits.
(#139 comfirmed that benchmarks on Travis will not happen)