### PR TITLE
Adds rotation matrix as method of Matrix3.

### DIFF
--- a/src/core/src/sim/mc/moves/rotate.rs
+++ b/src/core/src/sim/mc/moves/rotate.rs
@@ -132,37 +132,9 @@ impl MCMove for Rotate {
 /// `com` around the `axis` axis by `angle`. The `positions` array is
 /// overwritten with the new positions.
 fn rotate_around_axis(positions: &mut [Vector3D], com: Vector3D, axis: Vector3D, angle: f64) {
-    let rotation = rotation_matrix(&axis, angle);
+    let rotation = Matrix3::rotation(&axis, angle);
     for position in positions {
         let oldpos = *position - com;
         *position = com + rotation * oldpos;
     }
-}
-
-fn rotation_matrix(axis: &Vector3D, angle: f64) -> Matrix3 {
-    let sin = f64::sin(angle);
-    let cos = f64::cos(angle);
-
-    let x_sin = axis[0] * sin;
-    let y_sin = axis[1] * sin;
-    let z_sin = axis[2] * sin;
-    let one_minus_cos = 1.0 - cos;
-    let xy = axis[0] * axis[1] * one_minus_cos;
-    let xz = axis[0] * axis[2] * one_minus_cos;
-    let yz = axis[1] * axis[2] * one_minus_cos;
-
-    // Build the rotation matrix
-    let rotation = Matrix3::new(
-        (axis[0] * axis[0]) * one_minus_cos + cos,
-        xy + z_sin,
-        xz - y_sin,
-        xy - z_sin,
-        (axis[1] * axis[1]) * one_minus_cos + cos,
-        yz + x_sin,
-        xz + y_sin,
-        yz - x_sin,
-        (axis[2] * axis[2]) * one_minus_cos + cos
-    );
-
-    return rotation;
 }

--- a/src/core/src/types/matrix.rs
+++ b/src/core/src/types/matrix.rs
@@ -91,6 +91,51 @@ impl Matrix3 {
                        [m20, m21, m22]]}
     }
 
+
+    /// Returns rotation matrix given a rotation angle and an axis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lumol::types::{Vector3D, Matrix3};
+    /// let e1 = Vector3D::new(1.0f64, 0.0, 0.0);
+    /// let e3 = Vector3D::new(0.0f64, 0.0, 1.0);
+    /// let angle = 90f64.to_radians();
+    ///
+    /// let rotation = Matrix3::rotation(&(e1*2.0), angle);
+    /// let mut rot_vec = rotation * e3;
+    /// for i in 0..3 {
+    ///     rot_vec[i] = (rot_vec[i] * 1.0e8).round() / 1.0e8
+    /// };
+    /// assert_eq!(rot_vec, Vector3D::new(0.0, 1.0, 0.0));
+    /// ```
+    pub fn rotation(axis: &Vector3D, angle: f64) -> Matrix3 {
+        let n = axis.normalized();
+        let sin = f64::sin(angle);
+        let cos = f64::cos(angle);
+
+        let x_sin = n[0] * sin;
+        let y_sin = n[1] * sin;
+        let z_sin = n[2] * sin;
+        let one_minus_cos = 1.0 - cos;
+        let xy = n[0] * n[1] * one_minus_cos;
+        let xz = n[0] * n[2] * one_minus_cos;
+        let yz = n[1] * n[2] * one_minus_cos;
+
+        // Build the rotation matrix
+        Matrix3::new(
+            (n[0] * n[0]) * one_minus_cos + cos,
+            xy + z_sin,
+            xz - y_sin,
+            xy - z_sin,
+            (n[1] * n[1]) * one_minus_cos + cos,
+            yz + x_sin,
+            xz + y_sin,
+            yz - x_sin,
+            (n[2] * n[2]) * one_minus_cos + cos
+        )
+    }
+
     /// Compute the trace of the matrix
     /// # Examples
     /// ```


### PR DESCRIPTION
This PR moves the function `rotation_matrix` from the rotational MC move to be a method of `Matrix3` and adds a doctest.

I also modified the old function to compute the norm of `axis` inside the function.