### PR TITLE
Parallelize Ewald::kspace_virial

### DIFF
--- a/src/core/src/types/matrix.rs
+++ b/src/core/src/types/matrix.rs
@@ -4,6 +4,7 @@
 //! 3x3 matrix type.
 use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
 use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
+use std::iter;
 
 use types::{Vector3D, Zero, One};
 
@@ -430,6 +431,12 @@ impl One for Matrix3 {
     }
 }
 
+impl iter::Sum for Matrix3 {
+    fn sum<I>(iter: I) -> Self where I: Iterator<Item=Matrix3> {
+        iter.fold(Matrix3::zero(), |a, b| a + b)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // TODO: remove most of these when we can generate coverage from doc tests
@@ -644,5 +651,23 @@ mod tests {
         );
 
         assert_eq!(matrix.transposed(), transposed);
+    }
+
+    #[test]
+    fn iter_sum() {
+        let a = Matrix3::new(
+            1.0, 2.0, 4.0,
+            0.0, 1.0, 3.0,
+            0.0, 0.0, 1.0
+        );
+        let b = Matrix3::new(
+            7.0, -2.0, 5.0,
+            1.0, 1.0, 3.0,
+            0.0, -8.0, 3.0
+        );
+
+        let vec = vec![a, b, a];
+        let sum : Matrix3 = vec.into_iter().sum();
+        assert_eq!(sum, a + a + b);
     }
 }


### PR DESCRIPTION
This PR:
* implements parallelization for `Ewald::kspace_virial`
* implements `std::iter::Sum<Matrix3>` for `Matrix3` so that we can use `sum` on the parallel iterators

I'm still fiddling with parallel iterators, so any suggestion is very welcome, especially about readability :).