### PR TITLE
Replace Monte-Carlo => Monte Carlo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 Lumol is a classical molecular simulation engine that provides a solid base for
 developing new algorithms and methods. Using Lumol, you can customize the
 behavior of all the algorithms in a simulation. Adding a new force field,
-customizing Monte-Carlo moves or molecular dynamics integrators is easy and well
+customizing Monte Carlo moves or molecular dynamics integrators is easy and well
 documented.
 
 Lumol goals are to be flexible, reliable and extensible. For us, this means that
 this software should be:
 
 - **flexible**: the code can simulate all kind of systems, from proteins to
-  crystals, using various methods: molecular dynamics, Monte-Carlo, *etc.*
+  crystals, using various methods: molecular dynamics, Monte Carlo, *etc.*
 - **reliable**: the code is well tested, both at the function level; and at the
   simulation level, checking thermodynamic properties of the systems;
 - **extendable**: the code is modular, object-oriented, well documented,
@@ -30,7 +30,7 @@ you are interested, have some questions or want to participate, you can open a
 - Pair, molecular and electrostatic interactions (with Ewald or Wolf methods);
 - Energy minimization;
 - Molecular dynamics simulations in the NVE, NVT and NPT ensembles;
-- Monte-Carlo simulations in the NVT ensemble;
+- Monte Carlo simulations in the NVT ensemble;
 - and many others! Have a look at the [documentation](#documentation) for more
   information
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -4,7 +4,7 @@
 - [Installation](installation.md)
 
 - [First simulations](tutorial/intro.md)
-    - [Monte-Carlo of Argon](tutorial/argon.md)
+    - [Monte Carlo of Argon](tutorial/argon.md)
     - [Hello Sodium Chloride](tutorial/nacl.md)
     - [Molecular dynamics of water](tutorial/water.md)
     - [Gibbs simulation of ethane]()
@@ -24,7 +24,7 @@
     - [Potentials](input/potentials.md)
     - [Simulations](input/simulations.md)
     - [Molecular dynamics](input/md.md)
-    - [Monte-Carlo](input/mc.md)
+    - [Monte Carlo](input/mc.md)
     - [Minimization](input/min.md)
     - [Logging configuration](input/log.md)
 
@@ -32,7 +32,7 @@
     - [Adding potentials]()
     - [Adding outputs]()
     - [Extending Molecular dynamics]()
-    - [Extending Monte-Carlo]()
+    - [Extending Monte Carlo]()
     - [Adding propagators]()
 
 - [FAQ](faq.md)

--- a/doc/src/concepts/simulation.md
+++ b/doc/src/concepts/simulation.md
@@ -21,7 +21,7 @@ and output algorithms.
 
 Propagators are at the heart of a Simulation. They have the responsibility to
 update the system at each simulation step. Currently, three propagators exists:
-a molecular dynamics one, a Monte-Carlo one and a minimizer, for energy
+a molecular dynamics one, a Monte Carlo one and a minimizer, for energy
 minimization.
 
 ## Output algorithms

--- a/doc/src/input/mc.md
+++ b/doc/src/input/mc.md
@@ -1,7 +1,7 @@
-# Monte-Carlo
+# Monte Carlo
 
-If you want to perform a Monte-Carlo simulation, you have to set the propagator
-`type` to `"MonteCarlo"`. Every Monte-Carlo simulations needs a `temperature`
+If you want to perform a Monte Carlo simulation, you have to set the propagator
+`type` to `"MonteCarlo"`. Every Monte Carlo simulations needs a `temperature`
 and a set of `moves` (this set can consist of a single move).
 
 You can think of a "move" as a specific instruction to generate a new trial
@@ -18,7 +18,7 @@ a molecule.
 center of mass.
 * [Resize](input/mc.html#resize): Change the size of the simulation cell.
 
-Currently, all Monte-Carlo simulations are carried out using Metropolis
+Currently, all Monte Carlo simulations are carried out using Metropolis
 acceptance criteria.
 
 You can add all necessary information after the `[simulations.propagator]` label.
@@ -33,15 +33,15 @@ temperature with unit.
 for this move are updated. Updates use statistics of a moves' acceptance ratio so it
 is recommended to choose a sufficiently high number (>100).
 
-Naturally, Monte-Carlo simulations are carried out at constant
+Naturally, Monte Carlo simulations are carried out at constant
 temperature which is set using the `temperature` key.
 
-Different from Molecular Dynamics, Monte-Carlo simulations don't carry
+Different from Molecular Dynamics, Monte Carlo simulations don't carry
 information about the velocities of particles.
 As a consequence we cannot access temperature from the kinetic energy.
 
 ### Example
-A sample input for a Monte-Carlo simulation (in the NPT ensemble)
+A sample input for a Monte Carlo simulation (in the NPT ensemble)
 can look like so:
 
 ```toml

--- a/doc/src/input/simulations.md
+++ b/doc/src/input/simulations.md
@@ -19,7 +19,7 @@ thermostat = {type = "Berendsen", temperature = "400 K", timestep = 100}
 ```
 
 Two propagators are currently implemented: one for [molecular dynamics][MD]; and
-one for [Monte-Carlo][MC].
+one for [Monte Carlo][MC].
 
 [MD]: input/md.html
 [MC]: input/mc.html

--- a/doc/src/input/systems.md
+++ b/doc/src/input/systems.md
@@ -142,7 +142,7 @@ velocities = {init = "300 K"}
 
 where the `init` key will take the temperature as *string*. The velocities will
 be initialized from a Boltzmann distribution at the given temperature.
-Monte-Carlo simulations will not make any use of velocities since transition
+Monte Carlo simulations will not make any use of velocities since transition
 probabilities (i.e. how the system evolves) are based on the positions (and the
 underlying interactions) only.
 

--- a/doc/src/intro.md
+++ b/doc/src/intro.md
@@ -10,7 +10,7 @@ line tool as well as a library in your own code.
 Excited? Then let's start with an overview of this book:
 - [Installation](installation.html): Where to get and how to install Lumol.
 - [The first simulations](): Step-by-step tutorials on
-  how to perform basic molecular dynamics and Monte-Carlo simulations.
+  how to perform basic molecular dynamics and Monte Carlo simulations.
 - [Simulation concepts](concepts/intro.html): Learn about the details. How are
   systems assembled? How do system propagators work?
 - [Input files reference](input/intro.html): The complete reference for the
@@ -30,6 +30,6 @@ a `Simulation` contains everything needed to run a simulation with a system,
 
 A `System` is usually used in combination with one `Simulation` to explore the
 properties of the system. Sometimes multiple systems can be associated with the
-same simulation (in Gibbs ensemble Monte-Carlo or in parallel tempering); and
+same simulation (in Gibbs ensemble Monte Carlo or in parallel tempering); and
 sometimes multiple simulations can be associated with the same system, when
 running an energy minimization before a molecular dynamics run.

--- a/doc/src/tutorial/argon.md
+++ b/doc/src/tutorial/argon.md
@@ -1,8 +1,8 @@
-# Monte-Carlo simulation of Argon
+# Monte Carlo simulation of Argon
 
 So let's run a simulation with Lumol. The easiest system to simulate is a
 Lennard-Jones fluid, which is a good model for noble gases fluids. Here we will
-simulate super-critical argon using Metropolis Monte-Carlo algorithm.
+simulate super-critical argon using Metropolis Monte Carlo algorithm.
 
 For this simulation, you will need the initial configuration available
 [here][argon.xyz]. Download it and save it under the name `argon.xyz`.
@@ -63,7 +63,7 @@ outputs = [
 ```
 
 At the end we define how we propagate the system from one step to another. Here
-we are using a Monte-Carlo simulation at 500 K, and the only Monte-Carlo move is
+we are using a Monte Carlo simulation at 500 K, and the only Monte Carlo move is
 a translation of maximum amplitude of 1 A.
 
 ```toml

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -1,7 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
-//! Monte-Carlo simulation of a binary mixture of H20 and CO2.
+//! Monte Carlo simulation of a binary mixture of H20 and CO2.
 extern crate lumol;
 extern crate lumol_input as input;
 

--- a/examples/mc_npt_argon.rs
+++ b/examples/mc_npt_argon.rs
@@ -1,7 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
-//! Testing physical properties of a Lennard-Jones Argon using Monte-Carlo
+//! Testing physical properties of a Lennard-Jones Argon using Monte Carlo
 //! simulation.
 extern crate lumol;
 extern crate lumol_input as input;

--- a/examples/xenon.rs
+++ b/examples/xenon.rs
@@ -1,7 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
-//! Monte-Carlo simulation of a Xenon crystal melt.
+//! Monte Carlo simulation of a Xenon crystal melt.
 extern crate lumol;
 
 use lumol::sys::{Trajectory, UnitCell};
@@ -22,7 +22,7 @@ fn main() {
     });
     system.interactions_mut().add_pair("Xe", "Xe", PairInteraction::new(lj, 12.0));
 
-    // Create a Monte-Carlo propagator
+    // Create a Monte Carlo propagator
     let mut mc = MonteCarlo::new(units::from(500.0, "K").unwrap());
     // Add the `Translate` move with 0.5 A amplitude and 1.0 frequency
     mc.add(

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -707,7 +707,7 @@ impl Ewald {
 /// Thread-sade wrapper around Ewald implementing `CoulombicPotential`.
 ///
 /// This wrapper allow to share a Ewald solver between threads (make it `Send
-/// + Sync`) while still using caching in Monte-Carlo simulations (with
+/// + Sync`) while still using caching in Monte Carlo simulations (with
 /// interior mutability).
 pub struct SharedEwald(RwLock<Ewald>);
 

--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -60,7 +60,7 @@ use energy::PairRestriction;
 /// }
 ///
 /// // Not implementing `GlobalCache` means that we will not be able to use
-/// // `ShiftAll` in Monte-Carlo simulations.
+/// // `ShiftAll` in Monte Carlo simulations.
 /// impl GlobalCache for ShiftAll {
 ///     fn move_particles_cost(&self, _: &System, _: &[usize], _: &[Vector3D]) -> f64 {
 ///         unimplemented!()
@@ -105,9 +105,9 @@ impl_box_clone!(GlobalPotential, BoxCloneGlobal, box_clone_gobal);
 /// Energetic cache for global potentials.
 ///
 /// This trait provide all the functions needed by [EnergyCache][EnergyCache]
-/// to compute partial energy updates in Monte-Carlo simulations. You can use
+/// to compute partial energy updates in Monte Carlo simulations. You can use
 /// a `panic!`ing implementation for all methods if you never need to use a
-/// given [GlobalPotential][GlobalPotential] in Monte-Carlo simulations.
+/// given [GlobalPotential][GlobalPotential] in Monte Carlo simulations.
 ///
 /// All methods take a non-mutable `&self` receiver, which means you may want
 /// to wrap the implemntation in `RwLock` or `Mutex` to allow for inner
@@ -175,7 +175,7 @@ pub trait GlobalCache {
 
     /// Update the cache as needed after a call to `move_particles_cost`.
     ///
-    /// If the Monte-Carlo move is accepted, this function will be called and
+    /// If the Monte Carlo move is accepted, this function will be called and
     /// should update any cached quantity so that further call to
     /// `GlobalPotential::energy` gives the right value.
     fn update(&self);

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -5,7 +5,7 @@
 //! base for developing new algorithms and methods.
 //!
 //! Using Lumol, you can customize the behavior of all the algorithms in a
-//! simulation (from force fields to barostats and Monte-Carlo moves).
+//! simulation (from force fields to barostats and Monte Carlo moves).
 //!
 //! Lumol goals are to be:
 //!

--- a/src/core/src/sim/mc/mod.rs
+++ b/src/core/src/sim/mc/mod.rs
@@ -1,7 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
-//! Monte-Carlo Metropolis algorithms
+//! Monte Carlo Metropolis algorithms
 mod monte_carlo;
 pub use self::monte_carlo::{MonteCarlo, MoveCounter};
 

--- a/src/core/src/sim/mc/monte_carlo.rs
+++ b/src/core/src/sim/mc/monte_carlo.rs
@@ -1,7 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
-//! Metropolis Monte-Carlo propagator implementation
+//! Metropolis Monte Carlo propagator implementation
 use rand::{self, SeedableRng};
 
 use consts::K_BOLTZMANN;
@@ -10,13 +10,13 @@ use sim::{Propagator, TemperatureStrategy};
 
 use super::MCMove;
 
-/// Metropolis Monte-Carlo propagator
+/// Metropolis Monte Carlo propagator
 pub struct MonteCarlo {
     /// Boltzmann factor: beta = 1/(kB * T)
     beta: f64,
-    /// List of possible Monte-Carlo moves
+    /// List of possible Monte Carlo moves
     moves: Vec<(Box<MCMove>, MoveCounter)>,
-    /// Cummulative frequencies of the Monte-Carlo moves
+    /// Cummulative frequencies of the Monte Carlo moves
     frequencies: Vec<f64>,
     /// Specifies the number of moves after which an update of a move's
     /// amplitude is performed.
@@ -32,17 +32,17 @@ pub struct MonteCarlo {
 }
 
 impl MonteCarlo {
-    /// Create a new Monte-Carlo propagator at temperature `T`.
+    /// Create a new Monte Carlo propagator at temperature `T`.
     pub fn new(temperature: f64) -> MonteCarlo {
         let mut rng = Box::new(rand::XorShiftRng::new_unseeded());
         rng.reseed([2015u32, 42u32, 3u32, 12u32]);
         return MonteCarlo::from_rng(temperature, rng);
     }
 
-    /// Create a Monte-Carlo propagator at temperature `T`, using the `rng`
+    /// Create a Monte Carlo propagator at temperature `T`, using the `rng`
     /// random number generator.
     pub fn from_rng(temperature: f64, rng: Box<rand::Rng>) -> MonteCarlo {
-        assert!(temperature >= 0.0, "Monte-Carlo temperature must be positive");
+        assert!(temperature >= 0.0, "Monte Carlo temperature must be positive");
         MonteCarlo {
             beta: 1.0 / (K_BOLTZMANN * temperature),
             moves: Vec::new(),
@@ -54,7 +54,7 @@ impl MonteCarlo {
         }
     }
 
-    /// Add the `mcmove` Monte-Carlo move to this propagator, with frequency
+    /// Add the `mcmove` Monte Carlo move to this propagator, with frequency
     /// `frequency`. All calls to this function should happen before any
     /// simulation run.
     ///
@@ -64,7 +64,7 @@ impl MonteCarlo {
     pub fn add(&mut self, mcmove: Box<MCMove>, frequency: f64) {
         if self.initialized {
             fatal_error!(
-                "Monte-Carlo simulation has already been initialized, \
+                "Monte Carlo simulation has already been initialized, \
                 we can not add new moves."
             );
         }
@@ -72,7 +72,7 @@ impl MonteCarlo {
         self.frequencies.push(frequency);
     }
 
-    /// Add the `mcmove` Monte-Carlo move to the propagator.
+    /// Add the `mcmove` Monte Carlo move to the propagator.
     /// `frequency` describes how frequent a move is called, `target_acceptance`
     /// is the desired acceptance ratio of the move.
     ///
@@ -83,7 +83,7 @@ impl MonteCarlo {
     pub fn add_move_with_acceptance(&mut self, mcmove: Box<MCMove>, frequency: f64, target_acceptance: f64) {
         if self.initialized {
             fatal_error!(
-                "Monte-Carlo simulation has already been initialized, \
+                "Monte Carlo simulation has already been initialized, \
                 we can not add new moves."
             );
         }
@@ -111,14 +111,14 @@ impl MonteCarlo {
         assert_eq!(self.frequencies.len(), self.moves.len());
         if self.frequencies.is_empty() {
             warn!(
-                "No move in the Monte-Carlo simulation, \
+                "No move in the Monte Carlo simulation, \
                 did you forget to specify them?"
             );
             return;
         }
 
         if self.initialized {
-            error!("This Monte-Carlo simulation has already been initialized.");
+            error!("This Monte Carlo simulation has already been initialized.");
             return;
         }
 

--- a/src/core/src/sim/mc/moves/mod.rs
+++ b/src/core/src/sim/mc/moves/mod.rs
@@ -1,10 +1,10 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 G. Fraux — BSD license
 
-//! A Monte-Carlo simulation is based on a set of applicable moves.
+//! A Monte Carlo simulation is based on a set of applicable moves.
 //!
-//! For example, NVT Monte-Carlo will use the `Translate` move only for particles
-//! and add the `Rotate` moves for molecules. NPT Monte-Carlo will add the
+//! For example, NVT Monte Carlo will use the `Translate` move only for particles
+//! and add the `Rotate` moves for molecules. NPT Monte Carlo will add the
 //! `VolumeResize` move.
 //!
 //! In all this module, beta refers to the Boltzmann factor 1/(kB T)
@@ -12,7 +12,7 @@ use rand::Rng;
 
 use sys::{System, EnergyCache};
 
-/// The `MCMove` trait correspond to the set of methods used in Monte-Carlo
+/// The `MCMove` trait correspond to the set of methods used in Monte Carlo
 /// simulations.
 pub trait MCMove {
     /// Give a short description of this move

--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -12,7 +12,7 @@ use super::MCMove;
 use types::{Matrix3, One};
 use sys::{System, EnergyCache};
 
-/// Monte-Carlo move that changes the size of the simulation cell
+/// Monte Carlo move that changes the size of the simulation cell
 pub struct Resize {
     /// Delta for translation of the box length
     delta: f64,

--- a/src/core/src/sim/mc/moves/rotate.rs
+++ b/src/core/src/sim/mc/moves/rotate.rs
@@ -12,7 +12,7 @@ use super::select_molecule;
 use types::{Matrix3, Vector3D};
 use sys::{System, EnergyCache};
 
-/// Monte-Carlo move for rotating a rigid molecule
+/// Monte Carlo move for rotating a rigid molecule
 pub struct Rotate {
     /// Type of molecule to rotate. `None` means all molecules.
     moltype: Option<u64>,

--- a/src/core/src/sim/mc/moves/translate.rs
+++ b/src/core/src/sim/mc/moves/translate.rs
@@ -13,7 +13,7 @@ use super::select_molecule;
 use types::Vector3D;
 use sys::{System, EnergyCache};
 
-/// Monte-Carlo move for translating a molecule
+/// Monte Carlo move for translating a molecule
 pub struct Translate {
     /// Type of molecule to translate. `None` means all molecules.
     moltype: Option<u64>,

--- a/src/core/src/sim/propagator.rs
+++ b/src/core/src/sim/propagator.rs
@@ -5,7 +5,7 @@
 use sys::System;
 
 /// Possible temperature computation strategies. Different propagators needs
-/// different ways to compute the temperature: Monte-Carlo temperature is a
+/// different ways to compute the temperature: Monte Carlo temperature is a
 /// constant of the simulation, whereas for molecular dynamics we use the
 /// instantaneous velocities.
 pub enum TemperatureStrategy {

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -2,9 +2,9 @@
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
 //! Caching energy components for speeding up the energy computation in
-//! Monte-Carlo simulations.
+//! Monte Carlo simulations.
 //!
-//! In most of Monte-Carlo moves, only a very small subset of the system changes.
+//! In most of Monte Carlo moves, only a very small subset of the system changes.
 //! We can use that property to remove the need of recomputing most of the
 //! energy components, by storing them and providing update callbacks.
 use std::mem;
@@ -280,7 +280,7 @@ impl EnergyCache {
     ///
     /// This function is intended for use when all the molecules in the system
     /// are moved rigidly, for example when resizing the system in NPT
-    /// Monte-Carlo. It computes energy changes due to:
+    /// Monte Carlo. It computes energy changes due to:
     ///
     /// - non bonded pairs interactions;
     /// - Coulomb interactions;

--- a/src/input/src/simulations/mc.rs
+++ b/src/input/src/simulations/mc.rs
@@ -15,7 +15,7 @@ use simulations::get_input_path;
 impl FromTomlWithData for MonteCarlo {
     type Data = PathBuf;
     fn from_toml(config: &Table, root: PathBuf) -> Result<MonteCarlo> {
-        let temperature = try!(extract::str("temperature", config, "Monte-Carlo propagator"));
+        let temperature = try!(extract::str("temperature", config, "Monte Carlo propagator"));
         let temperature = try!(units::from_str(temperature));
 
         let mut mc = MonteCarlo::new(temperature);
@@ -23,32 +23,32 @@ impl FromTomlWithData for MonteCarlo {
         let has_update_frequency = config.get("update_frequency").is_some();
         if has_update_frequency {
             let update_frequency =
-                try!(extract::uint("update_frequency", config, "Monte-Carlo propagator"));
+                try!(extract::uint("update_frequency", config, "Monte Carlo propagator"));
             mc.set_amplitude_update_frequency(update_frequency);
         }
 
-        let moves = try!(extract::slice("moves", config, "Monte-Carlo propagator"));
+        let moves = try!(extract::slice("moves", config, "Monte Carlo propagator"));
         for mc_move in moves {
             let mc_move = try!(mc_move.as_table()
-                .ok_or(Error::from("All moves must be tables in Monte-Carlo")));
+                .ok_or(Error::from("All moves must be tables in Monte Carlo")));
 
             let frequency = if mc_move.get("frequency").is_some() {
-                try!(extract::number("frequency", mc_move, "Monte-Carlo move"))
+                try!(extract::number("frequency", mc_move, "Monte Carlo move"))
             } else {
                 1.0
             };
 
             let target_acceptance = if mc_move.get("target_acceptance").is_some() {
-                Some(try!(extract::number("target_acceptance", mc_move, "Monte-Carlo move")))
+                Some(try!(extract::number("target_acceptance", mc_move, "Monte Carlo move")))
             } else {
                 None
             };
 
-            let mc_move: Box<MCMove> = match try!(extract::typ(mc_move, "Monte-Carlo move")) {
+            let mc_move: Box<MCMove> = match try!(extract::typ(mc_move, "Monte Carlo move")) {
                 "Translate" => Box::new(try!(Translate::from_toml(mc_move, root.clone()))),
                 "Rotate" => Box::new(try!(Rotate::from_toml(mc_move, root.clone()))),
                 "Resize" => Box::new(try!(Resize::from_toml(mc_move, root.clone()))),
-                other => return Err(Error::from(format!("Unknown Monte-Carlo move '{}'", other))),
+                other => return Err(Error::from(format!("Unknown Monte Carlo move '{}'", other))),
             };
 
             match target_acceptance {

--- a/src/input/tests/simulation/bad/mc/mc-1.toml
+++ b/src/input/tests/simulation/bad/mc/mc-1.toml
@@ -9,5 +9,5 @@ nsteps = 1
 
 [simulations.propagator]
 type = "MonteCarlo"
-#^ Missing 'temperature' key in Monte-Carlo propagator
+#^ Missing 'temperature' key in Monte Carlo propagator
 

--- a/src/input/tests/simulation/bad/mc/mc-2.toml
+++ b/src/input/tests/simulation/bad/mc/mc-2.toml
@@ -10,5 +10,5 @@ nsteps = 1
 [simulations.propagator]
 type = "MonteCarlo"
 temperature = true
-#^ 'temperature' must be a string in Monte-Carlo propagator
+#^ 'temperature' must be a string in Monte Carlo propagator
 

--- a/src/input/tests/simulation/bad/mc/mc-3.toml
+++ b/src/input/tests/simulation/bad/mc/mc-3.toml
@@ -11,5 +11,5 @@ nsteps = 1
 type = "MonteCarlo"
 temperature = "300 K"
 mo = false
-#^ Missing 'moves' key in Monte-Carlo propagator
+#^ Missing 'moves' key in Monte Carlo propagator
 

--- a/src/input/tests/simulation/bad/mc/mc-4.toml
+++ b/src/input/tests/simulation/bad/mc/mc-4.toml
@@ -11,5 +11,5 @@ nsteps = 1
 type = "MonteCarlo"
 temperature = "300 K"
 moves = false
-#^ 'moves' must be an array in Monte-Carlo propagator
+#^ 'moves' must be an array in Monte Carlo propagator
 

--- a/src/input/tests/simulation/bad/mc/move-1.toml
+++ b/src/input/tests/simulation/bad/mc/move-1.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {bla = "ble"}
-    #^ Missing 'type' key in Monte-Carlo move
+    #^ Missing 'type' key in Monte Carlo move
 ]
 

--- a/src/input/tests/simulation/bad/mc/move-10.toml
+++ b/src/input/tests/simulation/bad/mc/move-10.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {type = "Translate", delta = "6 A", frequency = "6"}
-    #^ 'frequency' must be a number in Monte-Carlo move
+    #^ 'frequency' must be a number in Monte Carlo move
 ]
 

--- a/src/input/tests/simulation/bad/mc/move-14.toml
+++ b/src/input/tests/simulation/bad/mc/move-14.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {type = "Resize", pressure = "5.0 bar", delta = "6 A^3", frequency = "3"}
-    #^ 'frequency' must be a number in Monte-Carlo move
+    #^ 'frequency' must be a number in Monte Carlo move
 ]
 

--- a/src/input/tests/simulation/bad/mc/move-2.toml
+++ b/src/input/tests/simulation/bad/mc/move-2.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {type = true}
-    #^ 'type' key must be a string in Monte-Carlo move
+    #^ 'type' key must be a string in Monte Carlo move
 ]
 

--- a/src/input/tests/simulation/bad/mc/move-3.toml
+++ b/src/input/tests/simulation/bad/mc/move-3.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {type = "true"}
-    #^ Unknown Monte-Carlo move 'true'
+    #^ Unknown Monte Carlo move 'true'
 ]
 

--- a/src/input/tests/simulation/bad/mc/move-6.toml
+++ b/src/input/tests/simulation/bad/mc/move-6.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {type = "Rotate", delta = "6 A", frequency = "6"}
-    #^ 'frequency' must be a number in Monte-Carlo move
+    #^ 'frequency' must be a number in Monte Carlo move
 ]
 

--- a/src/input/tests/simulation/bad/mc/move_acceptance-1.toml
+++ b/src/input/tests/simulation/bad/mc/move_acceptance-1.toml
@@ -12,6 +12,6 @@ type = "MonteCarlo"
 temperature = "300 K"
 moves = [
     {type = "Rotate", delta = "6 A", frequency = 0.3, target_acceptance = "0.5"}
-    #^ 'target_acceptance' must be a number in Monte-Carlo move
+    #^ 'target_acceptance' must be a number in Monte Carlo move
 ]
 

--- a/src/input/tests/simulation/bad/mc/update_frequency-1.toml
+++ b/src/input/tests/simulation/bad/mc/update_frequency-1.toml
@@ -11,7 +11,7 @@ nsteps = 1
 type = "MonteCarlo"
 temperature = "300 K"
 update_frequency = -1
-#^ 'update_frequency' must be a positive integer in Monte-Carlo propagator
+#^ 'update_frequency' must be a positive integer in Monte Carlo propagator
 moves = [
     {type = "Rotate", delta = "6 A", frequency = 0.3, target_acceptance = 0.5}
 ]

--- a/src/input/tests/simulation/bad/mc/update_frequency-2.toml
+++ b/src/input/tests/simulation/bad/mc/update_frequency-2.toml
@@ -11,5 +11,5 @@ nsteps = 1
 type = "MonteCarlo"
 temperature = "300 K"
 update_frequency = "3"
-#^ 'update_frequency' must be a positive integer in Monte-Carlo propagator
+#^ 'update_frequency' must be a positive integer in Monte Carlo propagator
 

--- a/tests/mc-helium.rs
+++ b/tests/mc-helium.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2015-2016 Lumol's contributors — BSD license
 
 //! Testing physical properties of a Lennard-Jones gaz of Helium using
-//! Monte-Carlo simulation
+//! Monte Carlo simulation
 extern crate lumol;
 extern crate lumol_input as input;
 extern crate env_logger;

--- a/tests/mc-water.rs
+++ b/tests/mc-water.rs
@@ -11,7 +11,7 @@ use std::sync::{Once, ONCE_INIT};
 static START: Once = ONCE_INIT;
 
 
-// This test only run a Monte-Carlo simulation of water, but do not test
+// This test only run a Monte Carlo simulation of water, but do not test
 // anything for now. It should test the g(r) function someday.
 #[test]
 fn wolf() {


### PR DESCRIPTION
The first spelling is the french one, and does not apply in english.