### PR TITLE
Use a vector instead of a map for composition

### DIFF
--- a/src/core/src/sys/composition.rs
+++ b/src/core/src/sys/composition.rs
@@ -1,0 +1,117 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+
+use std::ops::{Index, IndexMut};
+use sys::ParticleKind;
+
+/// The system composition contains the number of particles of each kind
+/// in the system.
+///
+/// # Examples
+/// ```
+/// # use lumol::sys::{Composition, ParticleKind};
+/// let mut composition = Composition::new();
+/// composition.resize(10);
+///
+/// composition[ParticleKind(2)] = 56;
+/// composition[ParticleKind(8)] = 2;
+/// composition[ParticleKind(5)] = 42;
+///
+/// assert_eq!(composition[ParticleKind(2)], 56);
+/// assert_eq!(composition[ParticleKind(8)], 2);
+/// assert_eq!(composition[ParticleKind(5)], 42);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Composition(Vec<usize>);
+
+impl Composition {
+    /// Create a new empty composition
+    ///
+    /// # Examples
+    /// ```
+    /// # use lumol::sys::Composition;
+    /// let composition = Composition::new();
+    /// assert_eq!(composition.len(), 0);
+    /// ```
+    pub fn new() -> Composition {
+        Composition(Vec::new())
+    }
+
+    /// Get the size of the composition, *i.e.* the number of different
+    /// particle kinds in the composition.
+    ///
+    /// # Examples
+    /// ```
+    /// # use lumol::sys::Composition;
+    /// let mut composition = Composition::new();
+    /// assert_eq!(composition.len(), 0);
+    ///
+    /// composition.resize(10);
+    /// assert_eq!(composition.len(), 10);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Resize the composition to hold `size` items. The new particles kinds
+    /// start with no associated particles.
+    ///
+    /// # Examples
+    /// ```
+    /// # use lumol::sys::{Composition, ParticleKind};
+    /// let mut composition = Composition::new();
+    /// assert_eq!(composition.len(), 0);
+    ///
+    /// composition.resize(10);
+    /// assert_eq!(composition.len(), 10);
+    /// assert_eq!(composition[ParticleKind(8)], 0);
+    /// ```
+    pub fn resize(&mut self, size: usize) {
+        self.0.resize(size, 0)
+    }
+}
+
+
+impl Index<ParticleKind> for Composition {
+    type Output = usize;
+
+    #[inline]
+    fn index(&self, i: ParticleKind) -> &usize {
+        &self.0[i.0 as usize]
+    }
+}
+
+impl IndexMut<ParticleKind> for Composition {
+    #[inline]
+    fn index_mut(&mut self, i: ParticleKind) -> &mut usize {
+        &mut self.0[i.0 as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn len() {
+        let mut composition = Composition::new();
+        assert_eq!(composition.len(), 0);
+
+        composition.resize(10);
+        assert_eq!(composition.len(), 10);
+    }
+
+    #[test]
+    fn index() {
+        let mut composition = Composition::new();
+        composition.resize(10);
+
+        composition[ParticleKind(2)] = 56;
+        composition[ParticleKind(8)] = 2;
+        composition[ParticleKind(5)] = 42;
+
+        assert_eq!(composition[ParticleKind(2)], 56);
+        assert_eq!(composition[ParticleKind(8)], 2);
+        assert_eq!(composition[ParticleKind(5)], 42);
+    }
+}

--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -196,9 +196,9 @@ impl Compute for Virial {
         let volume = system.cell().volume();
         let composition = system.composition();
         for i in system.particle_kinds() {
-            let ni = composition[&i] as f64;
+            let ni = composition[i] as f64;
             for j in system.particle_kinds() {
-                let nj = composition[&j] as f64;
+                let nj = composition[j] as f64;
                 let potentials = system.interactions().pairs(i, j);
                 for potential in potentials {
                     virial += 2.0 * PI * ni * nj * potential.tail_virial() / volume;
@@ -323,6 +323,11 @@ mod test {
         interaction.enable_tail_corrections();
         system.interactions_mut().add_pair("F", "F", interaction);
 
+        /// unused interaction to check that we do handle this right
+        system.interactions_mut().add_pair("H", "O",
+            PairInteraction::new(Box::new(NullPotential), 0.0)
+        );
+
         let mut velocities = BoltzmannVelocities::new(unit_from(300.0, "K"));
         velocities.init(&mut system);
         return system;
@@ -364,6 +369,11 @@ mod test {
                 k: unit_from(100.0, "kJ/mol/deg^2"),
                 x0: unit_from(185.0, "deg")
         }));
+
+        /// unused interaction to check that we do handle this right
+        system.interactions_mut().add_pair("H", "O",
+            PairInteraction::new(Box::new(NullPotential), 0.0)
+        );
 
         return system;
     }

--- a/src/core/src/sys/energy.rs
+++ b/src/core/src/sys/energy.rs
@@ -60,15 +60,9 @@ impl<'a> EnergyEvaluator<'a> {
         let volume = self.system.volume();
         let composition = self.system.composition();
         for i in self.system.particle_kinds() {
-            let ni = match composition.get(&i) {
-                Some(ni) => *ni as f64,
-                None => continue,
-            };
+            let ni = composition[i] as f64;
             for j in self.system.particle_kinds() {
-                let nj = match composition.get(&j) {
-                    Some(nj) => *nj as f64,
-                    None => continue,
-                };
+                let nj = composition[j] as f64;
                 let potentials = self.system.interactions().pairs(i, j);
                 for potential in potentials {
                     energy += 2.0 * PI * ni * nj * potential.tail_energy() / volume;

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -11,6 +11,9 @@ pub use self::periodic::{PeriodicTable, ElementData};
 mod particles;
 pub use self::particles::{Particle, ParticleKind};
 
+mod composition;
+pub use self::composition::Composition;
+
 mod cells;
 pub use self::cells::{UnitCell, CellShape};
 

--- a/src/core/src/sys/systems.rs
+++ b/src/core/src/sys/systems.rs
@@ -11,13 +11,13 @@ use std::slice;
 use std::cmp::{min, max};
 use std::iter::IntoIterator;
 use std::i8;
-use std::collections::BTreeMap;
 
 use energy::PairInteraction;
 use energy::{BondPotential, AnglePotential, DihedralPotential};
 use types::{Vector3D, Matrix3, Zero};
 
 use super::{Particle, ParticleKind};
+use super::Composition;
 use super::Molecule;
 use super::{CONNECT_12, CONNECT_13, CONNECT_14, CONNECT_FAR};
 use super::UnitCell;
@@ -448,12 +448,14 @@ impl System {
     }
 
     /// Get the number of particles of each kind in the system
-    pub fn composition(&self) -> BTreeMap<ParticleKind, usize> {
-        let mut map = BTreeMap::new();
+    pub fn composition(&self) -> Composition {
+        let nkinds = self.particle_kinds().len();
+        let mut composition = Composition::new();
+        composition.resize(nkinds);
         for particle in &self.particles {
-            *map.entry(particle.kind).or_insert(0) += 1;
+            composition[particle.kind] += 1;
         }
-        return map;
+        return composition;
     }
 
     /// Get a list of all the particles kinds in the system.
@@ -850,10 +852,10 @@ mod tests {
 
         let compo = system.composition();
         assert_eq!(compo.len(), 4);
-        assert_eq!(compo[&ParticleKind(0)], 3);
-        assert_eq!(compo[&ParticleKind(1)], 2);
-        assert_eq!(compo[&ParticleKind(2)], 1);
-        assert_eq!(compo[&ParticleKind(3)], 1);
+        assert_eq!(compo[ParticleKind(0)], 3);
+        assert_eq!(compo[ParticleKind(1)], 2);
+        assert_eq!(compo[ParticleKind(2)], 1);
+        assert_eq!(compo[ParticleKind(3)], 1);
     }
 
     #[test]


### PR DESCRIPTION
We get O(1) composition retrivial, and no branching in energy and virial computation.

Also, the same bug as in #164 was present for virial: https://github.com/lumol-org/lumol/commit/88d3e9943ff78e14b37679007e2a410dc7e79ca0#diff-e3aff239f89d25b68f9bc977e87d49edL199