### PR TITLE
Remove the date from the copyright header

### DIFF
--- a/benches/argon.rs
+++ b/benches/argon.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 #[macro_use]
 extern crate bencher;

--- a/benches/nacl.rs
+++ b/benches/nacl.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 #[macro_use]
 extern crate bencher;

--- a/benches/propane.rs
+++ b/benches/propane.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 #[macro_use]
 extern crate bencher;

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -1,3 +1,6 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
+
 use lumol::sys::{System, Trajectory};
 use lumol_input::InteractionsInput;
 use std::path::Path;

--- a/benches/water.rs
+++ b/benches/water.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 #[macro_use]
 extern crate bencher;

--- a/examples/argon.rs
+++ b/examples/argon.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Molecular dynamics simulation of an Argon crystal melt.
 //!

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Monte Carlo simulation of a binary mixture of H20 and CO2.
 extern crate lumol;

--- a/examples/custom-potential.rs
+++ b/examples/custom-potential.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Using a custom potential in simulations
 extern crate lumol;

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Example of a run using input files for the simulation and the system
 //! This is the exact same simulation as the one in `binary.rs`

--- a/examples/mc_npt_argon.rs
+++ b/examples/mc_npt_argon.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing physical properties of a Lennard-Jones Argon using Monte Carlo
 //! simulation.

--- a/examples/mc_npt_ethane.rs
+++ b/examples/mc_npt_ethane.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 extern crate lumol;
 extern crate lumol_input as input;
 

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 extern crate lumol;
 extern crate lumol_input as input;
 

--- a/examples/minimization.rs
+++ b/examples/minimization.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Geometry minization of a molecule of water
 extern crate lumol;

--- a/examples/nacl.rs
+++ b/examples/nacl.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Molecular dynamics simulation of a crystal of sodium chloride, reading system and
 //! potentials from files.

--- a/examples/xenon.rs
+++ b/examples/xenon.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Monte Carlo simulation of a Xenon crystal melt.
 extern crate lumol;

--- a/src/bin/lumol.rs
+++ b/src/bin/lumol.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 extern crate lumol;
 extern crate lumol_input;

--- a/src/core/src/consts.rs
+++ b/src/core/src/consts.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Useful physical constants, expressed in the internal unit system.
 

--- a/src/core/src/energy/computations.rs
+++ b/src/core/src/energy/computations.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use energy::{Potential, PairPotential};
 

--- a/src/core/src/energy/functions.rs
+++ b/src/core/src/energy/functions.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use energy::Potential;
 use energy::{PairPotential, BondPotential, AnglePotential, DihedralPotential};

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use special::Error;
 

--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Global potential are potentials acting on the whole system at once
 //!

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use special::Error;
 use std::f64::consts::PI;

--- a/src/core/src/energy/mod.rs
+++ b/src/core/src/energy/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Interaction potentials for energy and forces computations
 //!

--- a/src/core/src/energy/pairs.rs
+++ b/src/core/src/energy/pairs.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use energy::{PairPotential, PairRestriction};
 use types::{Vector3D, Matrix3, One, Zero};

--- a/src/core/src/energy/restrictions.rs
+++ b/src/core/src/energy/restrictions.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Encoding restrictions in interactions.
 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Lumol is a classical molecular simulation engine that provides a solid
 //! base for developing new algorithms and methods.

--- a/src/core/src/out.rs
+++ b/src/core/src/out.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Saving properties of a system during a simulation
 use std::io::prelude::*;

--- a/src/core/src/parallel/mod.rs
+++ b/src/core/src/parallel/mod.rs
@@ -1,3 +1,6 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
+
 //! Parallelism related utilities
 
 pub mod prelude;

--- a/src/core/src/parallel/prelude.rs
+++ b/src/core/src/parallel/prelude.rs
@@ -1,3 +1,6 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
+
 //! Combination of `rayon::prelude` and lumol specific utilities
 
 pub use rayon::prelude::*;

--- a/src/core/src/parallel/shortcuts.rs
+++ b/src/core/src/parallel/shortcuts.rs
@@ -1,4 +1,5 @@
-use std::ops::Range;
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
 
 use rayon::prelude::*;
 use rayon::iter::{Map, MapFn};
@@ -15,7 +16,6 @@ use rayon::iter::{Map, MapFn};
 /// assert_eq!(-4950, s);
 /// ```
 pub trait ParallelShortcuts : IntoParallelIterator + Sized {
-
     /// Shortcut for `into_par_iter().map()`
     fn par_map<F, R>(self, map_op: F) -> Map<Self::Iter, MapFn<F>>
         where F: Fn(Self::Item) -> R + Sync, R: Send{

--- a/src/core/src/parallel/thread_local_store.rs
+++ b/src/core/src/parallel/thread_local_store.rs
@@ -1,3 +1,6 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
+
 use std::cell::RefCell;
 use std::ops::{AddAssign, Deref};
 
@@ -98,5 +101,3 @@ impl<T, F> Deref for ThreadLocalStore<T, F>
         self.inner.get_or(|| Box::new(RefCell::new((self.init)())))
     }
 }
-
-

--- a/src/core/src/sim/mc/mod.rs
+++ b/src/core/src/sim/mc/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Monte Carlo Metropolis algorithms
 mod monte_carlo;

--- a/src/core/src/sim/mc/monte_carlo.rs
+++ b/src/core/src/sim/mc/monte_carlo.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Metropolis Monte Carlo propagator implementation
 use rand::{self, SeedableRng};

--- a/src/core/src/sim/md/controls.rs
+++ b/src/core/src/sim/md/controls.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! While running a simulation, we often want to have control over some
 //! simulation parameters: the temperature, the pressure, etc. This is the goal

--- a/src/core/src/sim/md/integrators.rs
+++ b/src/core/src/sim/md/integrators.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use types::{Vector3D, Matrix3, One, Zero};
 use sys::System;
 

--- a/src/core/src/sim/md/mod.rs
+++ b/src/core/src/sim/md/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Molecular dynamics algorithms.
 mod integrators;

--- a/src/core/src/sim/md/molecular_dynamics.rs
+++ b/src/core/src/sim/md/molecular_dynamics.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use sys::System;
 use sim::{Propagator, TemperatureStrategy};

--- a/src/core/src/sim/min/minimization.rs
+++ b/src/core/src/sim/min/minimization.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Energy minimization algorithms
 use utils;

--- a/src/core/src/sim/min/mod.rs
+++ b/src/core/src/sim/min/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Energy minimization algorithms
 

--- a/src/core/src/sim/min/steepest_descent.rs
+++ b/src/core/src/sim/min/steepest_descent.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use utils;
 use sys::System;

--- a/src/core/src/sim/mod.rs
+++ b/src/core/src/sim/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Types and traits for representing simulation algorithms
 mod propagator;

--- a/src/core/src/sim/propagator.rs
+++ b/src/core/src/sim/propagator.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! A propagator is responsible for updating the system during a simulation
 use sys::System;

--- a/src/core/src/sim/simulations.rs
+++ b/src/core/src/sim/simulations.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use sys::System;
 use types::Vector3D;

--- a/src/core/src/sim/utils.rs
+++ b/src/core/src/sim/utils.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Module for small utility structs
 

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Caching energy components for speeding up the energy computation in
 //! Monte Carlo simulations.

--- a/src/core/src/sys/cells.rs
+++ b/src/core/src/sys/cells.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Simulations in computational chemistry are often made using periodic
 //! boundaries conditions. The `UnitCell` type represents the enclosing box of

--- a/src/core/src/sys/chfl.rs
+++ b/src/core/src/sys/chfl.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! [Chemfiles][Chemfiles] conversion for Lumol.
 //!

--- a/src/core/src/sys/composition.rs
+++ b/src/core/src/sys/composition.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use std::ops::{Index, IndexMut};
 use sys::ParticleKind;

--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Computing properties of a system
 use consts::K_BOLTZMANN;

--- a/src/core/src/sys/connect.rs
+++ b/src/core/src/sys/connect.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Data about bonds and angles in the system.
 use std::cmp::{min, max};

--- a/src/core/src/sys/energy.rs
+++ b/src/core/src/sys/energy.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Primitives for energy computation.
 //!

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! The `Interactions` type for storing particles types to potentials
 //! associations.

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! The `system` module provide a way to store data about a simulated system.
 //! These systems are represented by an `System` instance, made of a list of

--- a/src/core/src/sys/molecules.rs
+++ b/src/core/src/sys/molecules.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Data about molecules in the system.
 use std::collections::HashSet;

--- a/src/core/src/sys/particles.rs
+++ b/src/core/src/sys/particles.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! `Particle` type and manipulation.
 use types::{Vector3D, Zero};

--- a/src/core/src/sys/periodic.rs
+++ b/src/core/src/sys/periodic.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! The periodic module give access to information about "extended" elements.
 //! These elements can be real element like Hydrogen or Carbon, or composed

--- a/src/core/src/sys/systems.rs
+++ b/src/core/src/sys/systems.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! The base type for simulation data in `lumol` is the `System` type.
 //!

--- a/src/core/src/sys/veloc.rs
+++ b/src/core/src/sys/veloc.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! This module provides some ways to initialize the velocities in a `System`
 use rand::distributions::{Range, Normal, Sample};

--- a/src/core/src/types/arrays.rs
+++ b/src/core/src/types/arrays.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Multi-dimensional arrays based on ndarray
 use ndarray;

--- a/src/core/src/types/complex.rs
+++ b/src/core/src/types/complex.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Complex type
 use std::ops::{Add, Sub, Neg, Mul, Div};

--- a/src/core/src/types/matrix.rs
+++ b/src/core/src/types/matrix.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! 3x3 matrix type.
 use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};

--- a/src/core/src/types/mod.rs
+++ b/src/core/src/types/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Linear algebra types for Lumol.
 //!

--- a/src/core/src/types/vectors.rs
+++ b/src/core/src/types/vectors.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! 3-dimensional vector type
 use std::ops::{Add, Sub, Neg, Mul, Div, BitXor, Index, IndexMut};

--- a/src/core/src/units.rs
+++ b/src/core/src/units.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! This module allow to convert from and to the internal unit system.
 //!

--- a/src/core/src/utils/macros.rs
+++ b/src/core/src/utils/macros.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 /// A simple macro to implement Clone for Box<Trait>, without requiring that
 /// Trait is Clone. This works by creating a new trait (`BoxCloneTrait`) and

--- a/src/core/src/utils/mod.rs
+++ b/src/core/src/utils/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Various internal utilities, which do not have there own module
 #[macro_use]

--- a/src/core/src/utils/xyz.rs
+++ b/src/core/src/utils/xyz.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Read static string using the XYZ file format, and create the corresponding
 //! system.

--- a/src/input/src/error.rs
+++ b/src/input/src/error.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use std::io;
 use std::error;
 use std::fmt;

--- a/src/input/src/extract.rs
+++ b/src/input/src/extract.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::{Table, Value};
 use error::{Error, Result};
 

--- a/src/input/src/interactions/angles.rs
+++ b/src/input/src/interactions/angles.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::{Value, Table};
 
 use lumol::sys::System;

--- a/src/input/src/interactions/coulomb.rs
+++ b/src/input/src/interactions/coulomb.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::Value;
 
 use lumol::sys::System;

--- a/src/input/src/interactions/mod.rs
+++ b/src/input/src/interactions/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::de::from_str as parse;
 use toml::value::{Table, Value};
 

--- a/src/input/src/interactions/pairs.rs
+++ b/src/input/src/interactions/pairs.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::{Value, Table};
 
 use lumol::sys::System;

--- a/src/input/src/interactions/toml.rs
+++ b/src/input/src/interactions/toml.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Convert TOML values to Lumol types.
 use toml::value::Table;

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! This crate provide a way to build a Lumol simulation using input files.
 //!

--- a/src/input/src/simulations/logging.rs
+++ b/src/input/src/simulations/logging.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use error::Error;
 use extract;
 use Input;

--- a/src/input/src/simulations/mc.rs
+++ b/src/input/src/simulations/mc.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::Table;
 use std::path::PathBuf;
 

--- a/src/input/src/simulations/md.rs
+++ b/src/input/src/simulations/md.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::Table;
 
 use lumol::sim::md::*;

--- a/src/input/src/simulations/min.rs
+++ b/src/input/src/simulations/min.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::Table;
 
 use lumol::sim::min::*;

--- a/src/input/src/simulations/mod.rs
+++ b/src/input/src/simulations/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::de::from_str as parse;
 use toml::value::Table;
 

--- a/src/input/src/simulations/outputs.rs
+++ b/src/input/src/simulations/outputs.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::Table;
 use std::path::PathBuf;
 

--- a/src/input/src/simulations/propagator.rs
+++ b/src/input/src/simulations/propagator.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use lumol::sim::{Propagator, MolecularDynamics, MonteCarlo, Minimization};
 
 use error::{Error, Result};

--- a/src/input/src/simulations/simulations.rs
+++ b/src/input/src/simulations/simulations.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::Table;
 use lumol::sim::Simulation;
 

--- a/src/input/src/simulations/system.rs
+++ b/src/input/src/simulations/system.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 use toml::value::{Table, Value};
 
 use lumol::units;

--- a/src/input/tests/input.rs
+++ b/src/input/tests/input.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 extern crate test;
 extern crate walkdir;
 extern crate env_logger;

--- a/tests/mc-helium.rs
+++ b/tests/mc-helium.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing physical properties of a Lennard-Jones gaz of Helium using
 //! Monte Carlo simulation

--- a/tests/mc-water.rs
+++ b/tests/mc-water.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 extern crate lumol;
 extern crate lumol_input as input;
 extern crate env_logger;

--- a/tests/md-butane.rs
+++ b/tests/md-butane.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing molecular dynamics of butane
 extern crate lumol;

--- a/tests/md-helium.rs
+++ b/tests/md-helium.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing physical properties of a Lennard-Jones gas of Helium using Molecular
 //! dynamics

--- a/tests/md-methane.rs
+++ b/tests/md-methane.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing molecular dynamics of methane
 extern crate lumol;

--- a/tests/md-nacl.rs
+++ b/tests/md-nacl.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing physical properties of a NaCl crystal
 extern crate lumol;

--- a/tests/md-water.rs
+++ b/tests/md-water.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing physical properties of f-SPC water
 extern crate lumol;

--- a/tests/nist-lj.rs
+++ b/tests/nist-lj.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing energy of a Lennard-Jones fluid using data from
 //! https://www.nist.gov/mml/csd/chemical-informatics-research-group/lennard-jones-fluid-reference-calculations

--- a/tests/nist-spce.rs
+++ b/tests/nist-spce.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 G. Fraux — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 //! Testing energy computation for SPC/E water using data from
 //! https://www.nist.gov/mml/csd/chemical-informatics-research-group/spce-water-reference-calculations-9%C3%A5-cutoff

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,5 +1,5 @@
 // Lumol, an extensible molecular simulation engine
-// Copyright (C) 2015-2016 Lumol's contributors — BSD license
+// Copyright (C) Lumol's contributors — BSD license
 
 use lumol::out::Output;
 use lumol::sys::System;


### PR DESCRIPTION
As @g-bauer pointed out somewhere, it was out of date, and will be a hurdle to maintain. So let's get rid of it =)