### PR TITLE
Implement ParallelShortcuts for ndarray::Zip

### DIFF
--- a/src/core/src/parallel/prelude.rs
+++ b/src/core/src/parallel/prelude.rs
@@ -4,4 +4,5 @@
 //! Combination of `rayon::prelude` and lumol specific utilities
 
 pub use rayon::prelude::*;
+pub use ndarray_parallel::prelude::*;
 pub use super::ParallelShortcuts;

--- a/src/core/src/parallel/shortcuts.rs
+++ b/src/core/src/parallel/shortcuts.rs
@@ -1,8 +1,12 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
 
-use rayon::prelude::*;
+use std::ops::Range;
+
+use rayon::prelude::{ParallelIterator, IntoParallelIterator};
 use rayon::iter::{Map, MapFn};
+use ndarray_parallel::NdarrayIntoParallelIterator;
+use ndarray::Zip;
 
 
 /// Utility trait that adds shortcuts for `IntoParallelIterator` structs.
@@ -15,13 +19,34 @@ use rayon::iter::{Map, MapFn};
 /// let s = (0..100_i32).par_map(|i| -i).sum();
 /// assert_eq!(-4950, s);
 /// ```
-pub trait ParallelShortcuts : IntoParallelIterator + Sized {
+pub trait ParallelShortcuts: Sized {
+    /// The iterator type
+    type Iter: ParallelIterator;
+
+    /// Dummy function to make it work
+    fn _into_par_iter(self) -> Self::Iter;
 
     /// Shortcut for `into_par_iter().map()`
     fn par_map<F, R>(self, map_op: F) -> Map<Self::Iter, MapFn<F>>
-        where F: Fn(Self::Item) -> R + Sync, R: Send{
-        self.into_par_iter().map(map_op)
+        where F: Fn(<Self::Iter as ParallelIterator>::Item) -> R + Sync, R: Send {
+        self._into_par_iter().map(map_op)
     }
 }
 
-impl<T> ParallelShortcuts for T where T : IntoParallelIterator {}
+impl<T> ParallelShortcuts for Range<T>
+    where Range<T>: IntoParallelIterator {
+    type Iter = <Range<T> as IntoParallelIterator>::Iter;
+
+    fn _into_par_iter(self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}
+
+impl<Parts, D> ParallelShortcuts for Zip<Parts, D>
+    where Zip<Parts, D>: NdarrayIntoParallelIterator {
+    type Iter = <Zip<Parts, D> as NdarrayIntoParallelIterator>::Iter;
+
+    fn _into_par_iter(self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}

--- a/src/core/src/parallel/shortcuts.rs
+++ b/src/core/src/parallel/shortcuts.rs
@@ -23,22 +23,18 @@ pub trait ParallelShortcuts: Sized {
     /// The iterator type
     type Iter: ParallelIterator;
 
-    /// Dummy function to make it work
-    fn _into_par_iter(self) -> Self::Iter;
-
     /// Shortcut for `into_par_iter().map()`
     fn par_map<F, R>(self, map_op: F) -> Map<Self::Iter, MapFn<F>>
-        where F: Fn(<Self::Iter as ParallelIterator>::Item) -> R + Sync, R: Send {
-        self._into_par_iter().map(map_op)
-    }
+        where F: Fn(<Self::Iter as ParallelIterator>::Item) -> R + Sync, R: Send;
 }
 
 impl<T> ParallelShortcuts for Range<T>
     where Range<T>: IntoParallelIterator {
     type Iter = <Range<T> as IntoParallelIterator>::Iter;
 
-    fn _into_par_iter(self) -> Self::Iter {
-        self.into_par_iter()
+    fn par_map<F, R>(self, map_op: F) -> Map<Self::Iter, MapFn<F>>
+        where F: Fn(<Self::Iter as ParallelIterator>::Item) -> R + Sync, R: Send {
+        self.into_par_iter().map(map_op)
     }
 }
 
@@ -46,7 +42,8 @@ impl<Parts, D> ParallelShortcuts for Zip<Parts, D>
     where Zip<Parts, D>: NdarrayIntoParallelIterator {
     type Iter = <Zip<Parts, D> as NdarrayIntoParallelIterator>::Iter;
 
-    fn _into_par_iter(self) -> Self::Iter {
-        self.into_par_iter()
+    fn par_map<F, R>(self, map_op: F) -> Map<Self::Iter, MapFn<F>>
+        where F: Fn(<Self::Iter as ParallelIterator>::Item) -> R + Sync, R: Send {
+        self.into_par_iter().map(map_op)
     }
 }


### PR DESCRIPTION
The previous implementation did not work because `ndarray::Zip` does not implement `rayon::IntoParallelIterator` but a custom `ndarray_parallel::NdarrayIntoParallelIterator`, this PR changes that.

Note that we had to roll back to implementing `Parallelhortcuts` only for `Range<T>` and not for all `T` that implements `IntoParallelIterator`.