### PR TITLE
Use smallvec optimization for interactions storage

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "0.2"
 num-traits = "0.1"
 rayon = "0.7"
 thread_local = "0.3"
+smallvec = "0.4"
 
 [dev-dependencies]
 tempfile = "2.1"

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -54,6 +54,7 @@ extern crate rand;
 extern crate special;
 extern crate rayon;
 extern crate thread_local;
+extern crate smallvec;
 
 /// Log a fatal error, and then panic with the same message
 macro_rules! fatal_error {

--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -8,7 +8,6 @@ use std::f64::consts::PI;
 use consts::K_BOLTZMANN;
 use types::{Matrix3, Vector3D, Zero, One};
 use sys::System;
-use parallel::prelude::*;
 
 use parallel::prelude::*;
 use parallel::ThreadLocalStore;


### PR DESCRIPTION
This PR uses the [smallvec](http://doc.servo.org/smallvec/index.html) crate to store vectors of potentials on the stack up to the size of 2, and put it on the heap if more potentials are needed.

I picked the size of the inline storage to be 1. I think most of the time, bonds, angles and dihedrals will be of size 1, and pairs can reasonably be of size 1 and 2.

A local benchmark show that smallvec of size 2 can have a 30% impact on the performance: 
```
 $ cargo benchcmp smallvec1.log smallvec2.log --threshold=2
 name                                         smallvec1.log ns/iter  smallvec2.log ns/iter  diff ns/iter   diff %  speedup 
 argon::energy                                173,693                180,019                       6,326    3.64%   x 0.96 
 argon::forces                                339,561                313,700                     -25,861   -7.62%   x 1.08 
 nacl::cache_move_particle_ewald              367,766                354,958                     -12,808   -3.48%   x 1.04 
 nacl::cache_move_particle_wolf               95,581                 98,205                        2,624    2.75%   x 0.97 
 nacl::forces_ewald                           15,153,994             15,579,192                  425,198    2.81%   x 0.97 
 nacl::forces_wolf                            183,529                203,432                      19,903   10.84%   x 0.90 
 nacl::virial_ewald                           4,412,674              5,711,283                 1,298,609   29.43%   x 0.77 
 nacl::virial_wolf                            79,895                 81,948                        2,053    2.57%   x 0.97 
 propane::cache_move_all_rigid_molecules      1,415,019              1,173,040                  -241,979  -17.10%   x 1.21 
 propane::cache_move_particles                315,628                281,085                     -34,543  -10.94%   x 1.12 
 propane::forces                              437,252                587,030                     149,778   34.25%   x 0.74 
 propane::virial                              141,654                161,865                      20,211   14.27%   x 0.88 
 water::cache_move_all_rigid_molecules_ewald  7,255,339              6,902,289                  -353,050   -4.87%   x 1.05 
 water::cache_move_all_rigid_molecules_wolf   7,795,054              7,445,504                  -349,550   -4.48%   x 1.05 
 water::cache_move_particles_ewald            781,696                750,211                     -31,485   -4.03%   x 1.04 
 water::cache_move_particles_wolf             453,986                438,969                     -15,017   -3.31%   x 1.03 
 water::energy_wolf                           91,755                 96,072                        4,317    4.70%   x 0.96 
 water::forces_ewald                          23,166,571             22,505,711                 -660,860   -2.85%   x 1.03 
 water::forces_wolf                           208,982                216,240                       7,258    3.47%   x 0.97 
 water::virial_ewald                          6,436,767              7,035,567                   598,800    9.30%   x 0.91 
 water::virial_wolf                           104,295                110,475                       6,180    5.93%   x 0.94 
```

This PR needs benchmarks against master too, I'll run some later tonight.