### PR TITLE
Use ordered maps for interactions storage

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "0.2"
 num-traits = "0.1"
 rayon = "0.7"
 thread_local = "0.3"
+ordermap = "0.2"
 
 [dev-dependencies]
 tempfile = "2.1"

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -54,6 +54,7 @@ extern crate rand;
 extern crate special;
 extern crate rayon;
 extern crate thread_local;
+extern crate ordermap;
 
 /// Log a fatal error, and then panic with the same message
 macro_rules! fatal_error {

--- a/src/core/src/sys/interactions.rs
+++ b/src/core/src/sys/interactions.rs
@@ -8,6 +8,8 @@ use std::f64;
 use std::collections::BTreeMap;
 use std::cmp::{min, max};
 
+use ordermap::OrderMap;
+
 use energy::{PairInteraction, BondPotential, AnglePotential, DihedralPotential};
 use energy::{GlobalPotential, CoulombicPotential};
 
@@ -96,13 +98,13 @@ type DihedralKind = (Kind, Kind, Kind, Kind);
 #[derive(Clone)]
 pub struct Interactions {
     /// Pair potentials
-    pairs: BTreeMap<PairKind, Vec<PairInteraction>>,
+    pairs: OrderMap<PairKind, Vec<PairInteraction>>,
     /// Bond potentials
-    bonds: BTreeMap<BondKind, Vec<Box<BondPotential>>>,
+    bonds: OrderMap<BondKind, Vec<Box<BondPotential>>>,
     /// Angle potentials
-    angles: BTreeMap<AngleKind, Vec<Box<AnglePotential>>>,
+    angles: OrderMap<AngleKind, Vec<Box<AnglePotential>>>,
     /// Dihedral angles potentials
-    dihedrals: BTreeMap<DihedralKind, Vec<Box<DihedralPotential>>>,
+    dihedrals: OrderMap<DihedralKind, Vec<Box<DihedralPotential>>>,
     /// Coulombic potential solver
     coulomb: Option<Box<CoulombicPotential>>,
     /// Global potentials
@@ -121,10 +123,10 @@ impl Interactions {
     /// Create a new empty `Interactions`
     pub fn new() -> Interactions {
         Interactions{
-            pairs: BTreeMap::new(),
-            bonds: BTreeMap::new(),
-            angles: BTreeMap::new(),
-            dihedrals: BTreeMap::new(),
+            pairs: OrderMap::new(),
+            bonds: OrderMap::new(),
+            angles: OrderMap::new(),
+            dihedrals: OrderMap::new(),
             coulomb: None,
             globals: Vec::new(),
             kinds: ParticleKinds::new(),


### PR DESCRIPTION
This should be faster, because iteration is our main use case. But let the benchmarks speak!

This use the [ordermap](https://docs.rs/ordermap/0.2.10/ordermap/index.html) crate.