### PR TITLE
Use the builder pattern for trajectories

### DIFF
--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -1,7 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
 
-use lumol::sys::{System, Trajectory};
+use lumol::sys::{System, TrajectoryBuilder};
 use lumol_input::InteractionsInput;
 use std::path::Path;
 
@@ -10,15 +10,16 @@ use rand::{XorShiftRng, SeedableRng};
 pub fn get_system(name: &str) -> System {
     let data = Path::new(file!()).parent().unwrap().join("..").join("data");
 
-    let mut system = Trajectory::open(data.join(String::from(name) + ".pdb"))
-                                .and_then(|mut trajectory| trajectory.read())
-                                .unwrap();
+    let mut system = TrajectoryBuilder::new()
+                                       .open(data.join(String::from(name) + ".pdb"))
+                                       .and_then(|mut trajectory| trajectory.read())
+                                       .unwrap();
 
     InteractionsInput::new(data.join(String::from(name) + ".toml"))
                       .and_then(|input| input.read(&mut system))
                       .unwrap();
 
-    system
+    return system;
 }
 
 pub fn get_rng(seed: u32) -> XorShiftRng {

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -5,7 +5,7 @@
 extern crate lumol;
 extern crate lumol_input as input;
 
-use lumol::sys::{Molecule, Particle, Trajectory, UnitCell};
+use lumol::sys::{Molecule, Particle, TrajectoryBuilder, UnitCell};
 use lumol::sys::{read_molecule, molecule_type};
 use lumol::sim::Simulation;
 use lumol::sim::mc::{MonteCarlo, Translate, Rotate};
@@ -14,9 +14,9 @@ use lumol::units;
 use input::InteractionsInput;
 
 fn main() {
-    let mut system = Trajectory::open("data/binary.xyz")
-                                .and_then(|mut traj| traj.read())
-                                .unwrap();
+    let mut system = TrajectoryBuilder::new().open("data/binary.xyz")
+                                             .and_then(|mut traj| traj.read())
+                                             .unwrap();
     // Add bonds in the system
     for i in 0..system.molecules().len() / 3 {
         system.add_bond(3 * i,     3 * i + 1);

--- a/examples/mc_npt_argon.rs
+++ b/examples/mc_npt_argon.rs
@@ -6,7 +6,7 @@
 extern crate lumol;
 extern crate lumol_input as input;
 
-use lumol::sys::{System, Trajectory, UnitCell};
+use lumol::sys::{System, TrajectoryBuilder, UnitCell};
 use lumol::energy::{LennardJones, PairInteraction};
 use lumol::sim::Simulation;
 use lumol::sim::mc::{MonteCarlo, Translate, Resize};
@@ -18,9 +18,10 @@ use std::path::Path;
 fn get_system() -> System {
     let data_dir = Path::new(file!()).parent().unwrap();
     let configuration = data_dir.join("data").join("argon.xyz");
-    let mut system = Trajectory::open(configuration)
-                               .and_then(|mut traj| traj.read())
-                               .unwrap();
+    let mut system = TrajectoryBuilder::new()
+                                       .open(configuration)
+                                       .and_then(|mut traj| traj.read())
+                                       .unwrap();
 
     system.cell = UnitCell::cubic(31.0);
 

--- a/examples/mc_npt_ethane.rs
+++ b/examples/mc_npt_ethane.rs
@@ -3,7 +3,7 @@
 extern crate lumol;
 extern crate lumol_input as input;
 
-use lumol::sys::{UnitCell, System, Trajectory};
+use lumol::sys::{UnitCell, System, TrajectoryBuilder};
 use lumol::units;
 use lumol::sim::Simulation;
 use lumol::energy::{LennardJones, PairInteraction, PairRestriction, NullPotential};
@@ -15,9 +15,10 @@ use std::path::Path;
 fn get_system() -> System {
     let data_dir = Path::new(file!()).parent().unwrap().join("data");
     let configuration = data_dir.join("ethane.xyz");
-    let mut system = Trajectory::open(configuration)
-                                .and_then(|mut traj| traj.read_guess_bonds())
-                                .unwrap();
+    let mut system = TrajectoryBuilder::new()
+                                       .open(configuration)
+                                       .and_then(|mut traj| traj.read_guess_bonds())
+                                       .unwrap();
     system.cell = UnitCell::cubic(100.0);
 
     // Add intermolecular interactions

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -3,7 +3,7 @@
 extern crate lumol;
 extern crate lumol_input as input;
 
-use lumol::sys::{UnitCell, System, Trajectory};
+use lumol::sys::{UnitCell, System, TrajectoryBuilder};
 use lumol::units;
 use lumol::sim::Simulation;
 use lumol::energy::{PairInteraction, PairRestriction};
@@ -17,9 +17,10 @@ use std::path::Path;
 fn get_system() -> System {
     let data_dir = Path::new(file!()).parent().unwrap().join("data");
     let configuration = data_dir.join("spce.xyz");
-    let mut system = Trajectory::open(configuration)
-                                .and_then(|mut traj| traj.read_guess_bonds())
-                                .unwrap();
+    let mut system = TrajectoryBuilder::new()
+                                       .open(configuration)
+                                       .and_then(|mut traj| traj.read_guess_bonds())
+                                       .unwrap();
     system.cell = UnitCell::cubic(20.0);
 
     // Add intermolecular interactions

--- a/examples/nacl.rs
+++ b/examples/nacl.rs
@@ -6,7 +6,7 @@
 extern crate lumol;
 extern crate lumol_input as input;
 
-use lumol::sys::{UnitCell, Trajectory};
+use lumol::sys::{UnitCell, TrajectoryBuilder};
 use lumol::sys::veloc::{BoltzmannVelocities, InitVelocities};
 use lumol::sim::Simulation;
 use lumol::sim::md::{MolecularDynamics, RescaleThermostat};
@@ -15,9 +15,11 @@ use lumol::units;
 use input::InteractionsInput;
 
 fn main() {
-    // Read the system fromt the `data/NaCl.xyz` file
-    let mut trajectory = Trajectory::open("data/NaCl.xyz").unwrap();
-    let mut system = trajectory.read().unwrap();
+    // Read the system fromt the `data/nacl.xyz` file
+    let mut system = TrajectoryBuilder::new()
+                                       .open("data/nacl.xyz")
+                                       .and_then(|mut traj| traj.read())
+                                       .unwrap();
     // Set the unit cell, as there is no unit cell data in XYZ files
     system.cell = UnitCell::cubic(units::from(22.5608, "A").unwrap());
     // Read the interactions from the `data/NaCl.toml` TOML file

--- a/examples/xenon.rs
+++ b/examples/xenon.rs
@@ -4,7 +4,7 @@
 //! Monte Carlo simulation of a Xenon crystal melt.
 extern crate lumol;
 
-use lumol::sys::{Trajectory, UnitCell};
+use lumol::sys::{TrajectoryBuilder, UnitCell};
 use lumol::energy::{PairInteraction, LennardJones};
 use lumol::sim::Simulation;
 use lumol::sim::mc::{MonteCarlo, Translate};
@@ -12,8 +12,10 @@ use lumol::out::TrajectoryOutput;
 use lumol::units;
 
 fn main() {
-    let mut trajectory = Trajectory::open("data/xenon.xyz").unwrap();
-    let mut system = trajectory.read().unwrap();
+    let mut system = TrajectoryBuilder::new()
+                                       .open("data/xenon.xyz")
+                                       .and_then(|mut traj| traj.read())
+                                       .unwrap();
     system.cell = UnitCell::cubic(units::from(21.65, "A").unwrap());
 
     let lj = Box::new(LennardJones{

--- a/src/core/src/out.rs
+++ b/src/core/src/out.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use utils;
 use sys::System;
-use sys::{Trajectory, TrajectoryError};
+use sys::{TrajectoryBuilder, TrajectoryError, Trajectory, OpenMode};
 
 /// The `Output` trait define the interface for all the quantities outputted by
 /// the simulation during the run. An Output can be a text or a binary data
@@ -39,8 +39,9 @@ impl TrajectoryOutput {
     /// Create a new `TrajectoryOutput` writing to `filename`. The file is
     /// replaced if it already exists.
     pub fn new<P>(path: P) -> Result<TrajectoryOutput, TrajectoryError> where P: AsRef<Path> {
-        Ok(TrajectoryOutput{
-            file: try!(Trajectory::create(path))
+        let file = try!(TrajectoryBuilder::new().mode(OpenMode::Write).open(path));
+        Ok(TrajectoryOutput {
+            file: file
         })
     }
 }

--- a/src/core/src/sys/chfl.rs
+++ b/src/core/src/sys/chfl.rs
@@ -444,13 +444,6 @@ pub fn read_molecule<P: AsRef<Path>>(path: P) -> TrajectoryResult<(Molecule, Vec
     return Ok((molecule, particles));
 }
 
-/// Guess the bonds in a system using Chemfiles algorithm
-pub fn guess_bonds(system: &System) -> TrajectoryResult<System> {
-    let mut frame = try!(system.to_chemfiles());
-    try!(frame.guess_topology());
-    return frame.to_lumol();
-}
-
 
 #[cfg(test)]
 mod tests {

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -20,7 +20,7 @@ pub use self::cache::EnergyCache;
 
 mod chfl;
 pub use self::chfl::{Trajectory, TrajectoryError, TrajectoryBuilder, OpenMode};
-pub use self::chfl::{guess_bonds, read_molecule};
+pub use self::chfl::read_molecule;
 pub use self::chfl::ToChemfiles;
 
 pub mod veloc;

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -19,7 +19,7 @@ mod cache;
 pub use self::cache::EnergyCache;
 
 mod chfl;
-pub use self::chfl::{Trajectory, TrajectoryError};
+pub use self::chfl::{Trajectory, TrajectoryError, TrajectoryBuilder, OpenMode};
 pub use self::chfl::{guess_bonds, read_molecule};
 pub use self::chfl::ToChemfiles;
 

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -51,7 +51,7 @@ impl System {
         System::with_configuration(configuration)
     }
 
-    /// Create a system with the specified `configuration`
+    /// Create a system with the specified `configuration`, and no interactions.
     fn with_configuration(configuration: Configuration) -> System {
         System {
             configuration: configuration,
@@ -116,6 +116,26 @@ impl System {
             assert!(temperature >= 0.0, "External temperature must be positive");
         }
         self.external_temperature = temperature;
+    }
+
+
+
+    /// Guess the bonds in the configuration using the chemfiles algorithm.
+    ///
+    /// This function removes any existing bond, and tries to guess them using
+    /// a distance criteria. Because this function does a round trip to
+    /// chemfiles, it might be costly when dealing with big systems.
+    pub fn guess_bonds(&mut self) {
+        use ::sys::chfl::{ToChemfiles, ToLumol};
+        let mut frame = self.to_chemfiles().expect(
+            "can not convert the configuration to a chemfiles frame"
+        );
+        frame.guess_topology().expect(
+            "can not guess system topology in chemfiles"
+        );
+        *self = frame.to_lumol().expect(
+            "can not convert the chemfiles frame to a configuration"
+        );
     }
 }
 

--- a/src/core/src/utils/xyz.rs
+++ b/src/core/src/utils/xyz.rs
@@ -6,7 +6,6 @@
 
 use types::Vector3D;
 use sys::{System, Particle, UnitCell};
-use sys::guess_bonds;
 
 /// Read the `content` string, assuming XYZ format, and create the corresponding
 /// system. This function is intended for testing purposes only, and will
@@ -47,7 +46,7 @@ pub fn system_from_xyz(content: &str) -> System {
     }
 
     if lines[1].contains("bonds") {
-        return guess_bonds(&system).expect("Could not guess the bonds");
+        system.guess_bonds();
     }
 
     return system;

--- a/src/input/src/simulations/system.rs
+++ b/src/input/src/simulations/system.rs
@@ -21,7 +21,7 @@ impl Input {
 
         let file = try!(extract::str("file", config, "system"));
         let file = get_input_path(&self.path, file);
-        let mut trajectory = try!(Trajectory::open(file));
+        let mut trajectory = try!(TrajectoryBuilder::new().open(file));
 
         let mut with_cell = false;
         if let Some(cell) = try!(self.read_cell()) {

--- a/tests/nist-spce.rs
+++ b/tests/nist-spce.rs
@@ -9,7 +9,7 @@ extern crate lumol;
 extern crate lumol_input as input;
 
 use lumol::sys::{System, UnitCell};
-use lumol::sys::Trajectory;
+use lumol::sys::TrajectoryBuilder;
 use lumol::energy::{PairInteraction, LennardJones, NullPotential};
 use lumol::energy::{Ewald, SharedEwald, PairRestriction, CoulombicPotential};
 use lumol::consts::K_BOLTZMANN;
@@ -23,9 +23,10 @@ pub fn get_system(path: &str, cutoff: f64) -> System {
                                  .join("data")
                                  .join("nist-spce")
                                  .join(path);
-    let mut system = Trajectory::open(&path)
-                                .and_then(|mut traj| traj.read())
-                                .unwrap();
+    let mut system = TrajectoryBuilder::new()
+                                       .open(&path)
+                                       .and_then(|mut traj| traj.read())
+                                       .unwrap();
 
     let mut file = File::open(path).unwrap();
     let mut buffer = String::new();


### PR DESCRIPTION
A bit of cleanup that allow to expose all the `chemfiles::Trajectory` options to users of lumol.