### PR TITLE
Remove a few TODO from the code

### DIFF
--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -109,7 +109,6 @@ impl Ewald {
 
     /// Set the value of the alpha parameter for ewald computation. The default is to use
     /// `alpha = 3 * π / (4 * rc)`.
-    // TODO: add a way to set alpha ensuring O(n^3/2) behavior, and a given precision
     pub fn set_alpha(&mut self, alpha: f64) {
         assert!(alpha > 0.0, "Ewald parameter alpha must be positive");
         self.alpha = alpha;

--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -80,22 +80,15 @@ impl MCMove for Resize {
             }
         };
 
-        // Loop over all molecules in the system.
-        // We don't want to change the intramolecular distances
-        // so we compute the translation vector of the center-of-mass
-        // (com) of a molecule and apply it to all its particles.
-        // Note that to do this, the com of a molecule *always* has
-        // to reside inside the simulation cell.
-
-        // TODO: Check if system.size == system.molecules().len
-        // if that is the case, skip com computation since it is a
-        // system without molecules.
         for (mi, molecule) in self.previous.molecules().iter().enumerate() {
+            // We don't want to change the intramolecular distances
+            // so we compute the translation vector of the center-of-mass
+            // (com) of a molecule and apply it to all its particles.
+            // Note that to do this, the com of a molecule *always* has
+            // to reside inside the simulation cell.
             let old_com = system.molecule_com(mi);
             let frac_com = system.cell.fractional(&old_com);
-            // compute translation vector
             let delta_com = system.cell.cartesian(&frac_com) - old_com;
-            // loop over all particles (indices) in the molecule
             for pi in molecule.iter() {
                 system.particle_mut(pi).position += delta_com;
             }

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -312,7 +312,6 @@ impl EnergyCache {
         }
 
         // temporarily, recompute all interactions
-        // TODO: make this more efficient
         let new_coulomb = evaluator.coulomb();
         let new_global = evaluator.global();
 

--- a/src/core/src/sys/chfl.rs
+++ b/src/core/src/sys/chfl.rs
@@ -402,11 +402,49 @@ impl Trajectory {
         Ok(())
     }
 
-    /// Get access to the Chemfiles trajectory, and the associated features
-    // TODO: use partial privacy for this function
-    #[doc(hidden)]
-    pub fn as_chemfiles(&mut self) -> &mut chemfiles::Trajectory {
-        &mut self.0
+    /// Set the unit cell associated with a trajectory. This cell will be used
+    /// when reading and writing the files, replacing any unit cell in the
+    /// frames or files.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use lumol::sys::{TrajectoryBuilder, UnitCell};
+    /// let mut trajectory = TrajectoryBuilder::new()
+    ///                                       .open("file.xyz")
+    ///                                       .unwrap();
+    ///
+    /// trajectory.set_cell(&UnitCell::cubic(10.0)).unwrap();
+    /// let system = trajectory.read().unwrap();
+    ///
+    /// assert_eq!(system.cell, UnitCell::cubic(10.0));
+    /// ```
+    pub fn set_cell(&mut self, cell: &UnitCell) -> TrajectoryResult<()> {
+        let cell = try!(cell.to_chemfiles());
+        try!(self.0.set_cell(&cell));
+        Ok(())
+    }
+
+    /// Set the topology associated with this trajectory by reading the first
+    /// frame of the file at the given `path` and extracting the topology of
+    /// this frame. This topology will be used to replace any existing topology
+    /// when reading or writing with this trajectory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use lumol::sys::TrajectoryBuilder;
+    /// let mut trajectory = TrajectoryBuilder::new()
+    ///                                       .open("file.xyz")
+    ///                                       .unwrap();
+    ///
+    /// trajectory.set_topology_file("topology.pdb").unwrap();
+    /// // The system will contain the topology from topology.pdb
+    /// let system = trajectory.read().unwrap();
+    /// ```
+    pub fn set_topology_file(&mut self, path: &str) -> TrajectoryResult<()> {
+        try!(self.0.set_topology_file(path));
+        Ok(())
     }
 }
 

--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -217,8 +217,7 @@ impl Compute for Virial {
             let ni = composition[i] as f64;
             for j in system.particle_kinds() {
                 let nj = composition[j] as f64;
-                let potentials = system.pair_potentials_for_kinds(i, j);
-                for potential in potentials {
+                for potential in system.interactions().pairs(i, j) {
                     virial += 2.0 * PI * ni * nj * potential.tail_virial() / volume;
                 }
             }

--- a/src/core/src/sys/config/molecules.rs
+++ b/src/core/src/sys/config/molecules.rs
@@ -70,7 +70,6 @@ impl Molecule {
 
     /// Does this molecule contains the particle `i`
     pub fn contains(&self, i: usize) -> bool {
-        // TODO: use Range::contains when stable
         self.range.start <= i && i < self.range.end
     }
 
@@ -135,8 +134,8 @@ impl Molecule {
                     } else if angle.i() == bond3.i() && angle.j() != bond3.j() {
                         Dihedral::new(bond3.j(), angle.i(), angle.j(), angle.k())
                     } else {
-                        // TODO: (angle.k == bond3.i || angle.k == bond3.j)
-                        // is an improper dihedral.
+                        // (angle.k == bond3.i || angle.k == bond3.j) is an
+                        // improper dihedral.
                         continue;
                     };
                     self.dihedrals.insert(dihedral);

--- a/src/core/src/sys/config/particles.rs
+++ b/src/core/src/sys/config/particles.rs
@@ -33,8 +33,7 @@ pub struct Particle {
     /// and to use either `String` of `&str` to set it.
     name: String,
     /// Particle kind, an index for potentials lookup
-    // TODO: use pub(super) here to prevent modification from outside
-    pub kind: ParticleKind,
+    pub(in ::sys) kind: ParticleKind,
     /// Particle mass
     pub mass: f64,
     /// Particle charge

--- a/src/core/src/sys/energy.rs
+++ b/src/core/src/sys/energy.rs
@@ -68,8 +68,7 @@ impl<'a> EnergyEvaluator<'a> {
             let ni = composition[i] as f64;
             for j in self.system.particle_kinds() {
                 let nj = composition[j] as f64;
-                let potentials = self.system.pair_potentials_for_kinds(i, j);
-                for potential in potentials {
+                for potential in self.system.interactions().pairs(i, j) {
                     energy += 2.0 * PI * ni * nj * potential.tail_energy() / volume;
                 }
             }

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -21,7 +21,6 @@ pub use self::cache::EnergyCache;
 mod chfl;
 pub use self::chfl::{Trajectory, TrajectoryError, TrajectoryBuilder, OpenMode};
 pub use self::chfl::read_molecule;
-pub use self::chfl::ToChemfiles;
 
 pub mod veloc;
 pub mod compute;

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -203,15 +203,9 @@ impl System {
         return pairs;
     }
 
-    /// Get the list of pair potential acting on the
-    // TODO: use pub(crate) for interactions instead, this function is only
-    // used for tail corrections.
-    #[doc(hidden)]
-    pub fn pair_potentials_for_kinds(&self, kind_i: ParticleKind, kind_j: ParticleKind) -> &[PairInteraction] {
-        // No warning if there is no potential. This shoud be fine because
-        // most of the time, this function should be called after
-        // `pair_potentials`.
-        return self.interactions.pairs(kind_i, kind_j);
+    /// Get read-only access to the interactions for this system
+    pub(crate) fn interactions(&self) -> &Interactions {
+        &self.interactions
     }
 
     /// Get the list of bonded potential acting between the particles at indexes

--- a/src/core/src/types/matrix.rs
+++ b/src/core/src/types/matrix.rs
@@ -441,8 +441,6 @@ impl iter::Sum for Matrix3 {
 
 #[cfg(test)]
 mod tests {
-    // TODO: remove most of these when we can generate coverage from doc tests
-    // see https://github.com/rust-lang/rust/issues/36956
     use super::*;
     use types::{Vector3D, Zero, One};
 

--- a/src/input/src/interactions/angles.rs
+++ b/src/input/src/interactions/angles.rs
@@ -12,11 +12,8 @@ use extract;
 use super::InteractionsInput;
 
 impl InteractionsInput {
-    /// Read the "angles" section from the potential configuration. This is an
-    /// internal function, public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_angles(&self, system: &mut System) -> Result<()> {
+    /// Read the "angles" section from the potential configuration.
+    pub(crate) fn read_angles(&self, system: &mut System) -> Result<()> {
         let angles = match self.config.get("angles") {
             Some(angles) => angles,
             None => return Ok(())
@@ -48,11 +45,8 @@ impl InteractionsInput {
         Ok(())
     }
 
-    /// Read the "dihedrals" section from the potential configuration. This is
-    /// an internal function, public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_dihedrals(&self, system: &mut System) -> Result<()> {
+    /// Read the "dihedrals" section from the potential configuration.
+    pub(crate) fn read_dihedrals(&self, system: &mut System) -> Result<()> {
         let dihedrals = match self.config.get("dihedrals") {
             Some(dihedrals) => dihedrals,
             None => return Ok(())

--- a/src/input/src/interactions/coulomb.rs
+++ b/src/input/src/interactions/coulomb.rs
@@ -11,11 +11,8 @@ use super::read_restriction;
 use super::InteractionsInput;
 
 impl InteractionsInput {
-    /// Read the "coulomb" section from the potential configuration. This is an
-    /// internal function, public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_coulomb(&self, system: &mut System) -> Result<()> {
+    /// Read the "coulomb" section from the potential configuration.
+    pub(crate) fn read_coulomb(&self, system: &mut System) -> Result<()> {
         let coulomb = match self.config.get("coulomb") {
             Some(coulomb) => coulomb,
             None => return Ok(())
@@ -61,11 +58,8 @@ impl InteractionsInput {
         }
     }
 
-    /// Read the "charges" from the potential configuration. This is an internal
-    /// function, public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_charges(&self, system: &mut System) -> Result<()> {
+    /// Read the "charges" from the potential configuration.
+    pub(crate) fn read_charges(&self, system: &mut System) -> Result<()> {
         let charges = match self.config.get("charges") {
             Some(charges) => charges,
             None => return Ok(())

--- a/src/input/src/interactions/mod.rs
+++ b/src/input/src/interactions/mod.rs
@@ -35,9 +35,7 @@ impl InteractionsInput {
     }
 
     /// Read the interactions from a TOML formatted string.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn from_string(string: &str) -> Result<InteractionsInput> {
+    pub(crate) fn from_string(string: &str) -> Result<InteractionsInput> {
         let config = try!(parse(string).map_err(|err| {
             Error::TOML(Box::new(err))
         }));
@@ -45,11 +43,8 @@ impl InteractionsInput {
         return InteractionsInput::from_toml(config.clone());
     }
 
-    /// Read the interactions from a TOML table. This is an internal function,
-    /// public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn from_toml(config: Table) -> Result<InteractionsInput> {
+    /// Read the interactions from a TOML table.
+    pub(crate) fn from_toml(config: Table) -> Result<InteractionsInput> {
         Ok(InteractionsInput{
             config: config
         })

--- a/src/input/src/interactions/pairs.rs
+++ b/src/input/src/interactions/pairs.rs
@@ -52,11 +52,8 @@ impl<'a> GlobalInformation<'a> {
 }
 
 impl InteractionsInput {
-    /// Read the "pairs" section from the potential configuration. This is an
-    /// internal function, public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_pairs(&self, system: &mut System) -> Result<()> {
+    /// Read the "pairs" section from the potential configuration.
+    pub(crate) fn read_pairs(&self, system: &mut System) -> Result<()> {
         let pairs = match self.config.get("pairs") {
             Some(pairs) => pairs,
             None => return Ok(())
@@ -147,11 +144,8 @@ impl InteractionsInput {
         Ok(())
     }
 
-    /// Read the "bonds" section from the potential configuration. This is an
-    /// internal function, public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_bonds(&self, system: &mut System) -> Result<()> {
+    /// Read the "bonds" section from the potential configuration.
+    pub(crate) fn read_bonds(&self, system: &mut System) -> Result<()> {
         let bonds = match self.config.get("bonds") {
             Some(bonds) => bonds,
             None => return Ok(())

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -89,7 +89,7 @@ mod simulations;
 
 pub use self::error::{Error, Result};
 pub use self::interactions::InteractionsInput;
-pub use self::simulations::Input;
+pub use self::simulations::{Input, Config};
 
 /// Convert a TOML table to a Rust type.
 pub trait FromToml: Sized {

--- a/src/input/src/simulations/logging.rs
+++ b/src/input/src/simulations/logging.rs
@@ -73,9 +73,7 @@ impl Drop for EnsureLogger {
 
 impl Input {
     /// Setup the logger from the input file or to stdout as a default.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn setup_logging(&self) -> Result<(), Error> {
+    pub(crate) fn setup_logging(&self) -> Result<(), Error> {
         let _guard = EnsureLogger;
         if let Some(loggers) = self.config.get("log") {
             let loggers = try!(loggers.as_table().ok_or(

--- a/src/input/src/simulations/md.rs
+++ b/src/input/src/simulations/md.rs
@@ -132,7 +132,6 @@ impl FromTomlWithData for BerendsenBarostat {
 impl FromTomlWithData for AnisoBerendsenBarostat {
     type Data = f64;
     fn from_toml(config: &Table, timestep: f64) -> Result<AnisoBerendsenBarostat> {
-        // TODO: implement a way to give the stress matrix
         let pressure = try!(extract::str("pressure", config, "anisotropic Berendsen barostat"));
         let pressure = try!(units::from_str(pressure));
         let tau = try!(extract::number("timestep", config, "anisotropic Berendsen barostat"));

--- a/src/input/src/simulations/mod.rs
+++ b/src/input/src/simulations/mod.rs
@@ -53,9 +53,7 @@ impl Input {
     }
 
     /// Read the `Input` from a TOML formatted string.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn from_str(path: PathBuf, string: &str) -> Result<Input> {
+    pub(crate) fn from_str(path: PathBuf, string: &str) -> Result<Input> {
         let config = try!(parse(string).map_err(|err| {
             Error::TOML(Box::new(err))
         }));

--- a/src/input/src/simulations/outputs.rs
+++ b/src/input/src/simulations/outputs.rs
@@ -12,11 +12,8 @@ use extract;
 use super::Input;
 
 impl Input {
-    /// Get the the simulation outputs. This is an internal function, public
-    /// because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_outputs(&self) -> Result<Vec<(Box<Output>, u64)>> {
+    /// Get the the simulation outputs.
+    pub(crate) fn read_outputs(&self) -> Result<Vec<(Box<Output>, u64)>> {
         let config = try!(self.simulation_table());
         if let Some(outputs) = config.get("outputs") {
             let outputs = try!(outputs.as_array().ok_or(

--- a/src/input/src/simulations/propagator.rs
+++ b/src/input/src/simulations/propagator.rs
@@ -8,11 +8,8 @@ use extract;
 use super::Input;
 
 impl Input {
-    /// Get the the simulation propagator. This is an internal function, public
-    /// because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_propagator(&self) -> Result<Box<Propagator>> {
+    /// Get the the simulation propagator.
+    pub(crate) fn read_propagator(&self) -> Result<Box<Propagator>> {
         let config = try!(self.simulation_table());
         let propagator = try!(extract::table("propagator", config, "simulation"));
         match try!(extract::typ(propagator, "propagator")) {

--- a/src/input/src/simulations/simulations.rs
+++ b/src/input/src/simulations/simulations.rs
@@ -8,10 +8,7 @@ use extract;
 use super::Input;
 
 impl Input {
-    /// Get the the simulation. This is an internal function, public because of
-    /// the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
+    /// Get the the simulation.
     pub fn read_simulation(&self) -> Result<Simulation> {
         let propagator = try!(self.read_propagator());
         let mut simulation = Simulation::new(propagator);
@@ -22,11 +19,8 @@ impl Input {
         Ok(simulation)
     }
 
-    /// Get the number of steps in the simulation. This is an internal function,
-    /// public because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn read_nsteps(&self) -> Result<usize> {
+    /// Get the number of steps in the simulation.
+    pub(crate) fn read_nsteps(&self) -> Result<usize> {
         let simulation = try!(self.simulation_table());
         let nsteps = try!(simulation.get("nsteps").ok_or(
             Error::from("Missing 'nsteps' key in simulation")
@@ -39,11 +33,8 @@ impl Input {
         Ok(nsteps as usize)
     }
 
-    /// Get the simulation TOML table. This is an internal function, public
-    /// because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
-    pub fn simulation_table(&self) -> Result<&Table> {
+    /// Get the simulation TOML table.
+    pub(crate) fn simulation_table(&self) -> Result<&Table> {
         let simulations = try!(extract::slice("simulations", &self.config, "input file"));
         if simulations.len() != 1 {
             return Err(Error::from(

--- a/src/input/src/simulations/system.rs
+++ b/src/input/src/simulations/system.rs
@@ -20,16 +20,16 @@ impl Input {
         let file = get_input_path(&self.path, file);
         let mut trajectory = try!(TrajectoryBuilder::new().open(file));
 
-        let mut with_cell = false;
-        if let Some(cell) = try!(self.read_cell()) {
-            let cell = try!(cell.to_chemfiles());
-            try!(trajectory.as_chemfiles().set_cell(&cell));
-            with_cell = true;
-        }
+        let with_cell = if let Some(cell) = try!(self.read_cell()) {
+            try!(trajectory.set_cell(&cell));
+            true
+        } else {
+            false
+        };
 
         if config.get("topology").is_some() {
             let topology = try!(extract::str("topology", config, "system"));
-            try!(trajectory.as_chemfiles().set_topology_file(topology));
+            try!(trajectory.set_topology_file(topology));
         }
 
         let guess_bonds = if let Some(guess_bonds) = config.get("guess_bonds") {

--- a/src/input/src/simulations/system.rs
+++ b/src/input/src/simulations/system.rs
@@ -12,10 +12,7 @@ use {Input, InteractionsInput};
 use simulations::get_input_path;
 
 impl Input {
-    /// Get the the simulated system. This is an internal function, public
-    /// because of the code organization.
-    // TODO: use restricted privacy here
-    #[doc(hidden)]
+    /// Get the the simulated system.
     pub fn read_system(&self) -> Result<System> {
         let config = try!(self.system_table());
 


### PR DESCRIPTION
Now that rust 1.18 is out, we can use restricted privacy (`pub(crate)`), and remove a few todos from the code.