### PR TITLE
Remove Ewald RwLock

### DIFF
--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -86,7 +86,7 @@ use energy::PairRestriction;
 /// assert_eq!(system.forces(), vec![Vector3D::zero(); 3]);
 /// assert_eq!(system.virial(), Matrix3::zero());
 /// ```
-pub trait GlobalPotential: GlobalCache + BoxCloneGlobal + Send + Sync {
+pub trait GlobalPotential: GlobalCache + BoxCloneGlobal {
     /// Return the cut off radius.
     fn cutoff(&self) -> Option<f64>;
     /// Compute the energetic contribution of this potential
@@ -109,8 +109,7 @@ impl_box_clone!(GlobalPotential, BoxCloneGlobal, box_clone_gobal);
 /// given [GlobalPotential][GlobalPotential] in Monte Carlo simulations.
 ///
 /// All methods take a non-mutable `&self` receiver, which means you may want
-/// to wrap the implemntation in `RwLock` or `Mutex` to allow for inner
-/// mutability while still implementing `Send + Sync`.
+/// to wrap the implemntation in `RefCell` to allow inner mutability.
 ///
 /// [EnergyCache]: ../sys/struct.EnergyCache.html
 /// [GlobalPotential]: trait.GlobalPotential.html

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -9,7 +9,7 @@
 //! energy components, by storing them and providing update callbacks.
 use std::mem;
 
-use sys::System;
+use sys::{System, EnergyEvaluator};
 use types::{Vector3D, Array2};
 
 /// Callback for updating a cache. It also take an `&mut System` argument for
@@ -82,7 +82,7 @@ impl EnergyCache {
         for i in 0..system.size() {
             for j in (i + 1)..system.size() {
                 let r = system.nearest_image(i, j).norm();
-                let energy = evaluator.pair(r, i, j);
+                let energy = EnergyEvaluator::pair(system, system.local_potentials(), r, i, j);
                 self.pairs_cache[(i, j)] = energy;
                 self.pairs_cache[(j, i)] = energy;
                 self.pairs += energy;
@@ -155,7 +155,7 @@ impl EnergyCache {
                 if idxes.contains(&part_j) {continue}
 
                 let r = system.cell.distance(&system.particle(part_j).position, &newpos[i]);
-                let energy = evaluator.pair(r, part_i, part_j);
+                let energy = EnergyEvaluator::pair(system, system.local_potentials(), r, part_i, part_j);
 
                 pairs_delta += energy;
                 new_pairs[(part_i, part_j)] += energy;
@@ -169,7 +169,7 @@ impl EnergyCache {
         for (i, &part_i) in idxes.iter().enumerate() {
             for (j, &part_j) in idxes.iter().enumerate().skip(i + 1) {
                 let r = system.cell.distance(&newpos[i], &newpos[j]);
-                let energy = evaluator.pair(r, part_i, part_j);
+                let energy = EnergyEvaluator::pair(system, system.local_potentials(), r, part_i, part_j);
 
                 pairs_delta += energy;
                 new_pairs[(part_i, part_j)] += energy;
@@ -301,7 +301,7 @@ impl EnergyCache {
                             &system.particle(pi).position,
                             &system.particle(pj).position
                         );
-                        let energy = evaluator.pair(r, pi, pj);
+                        let energy = EnergyEvaluator::pair(system, system.local_potentials(), r, pi, pj);
                         pairs_delta += energy;
                         new_pairs[(pi, pj)] += energy;
                         new_pairs[(pj, pi)] += energy;

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -10,7 +10,7 @@ mod system;
 pub use self::system::System;
 
 mod interactions;
-use self::interactions::Interactions;
+use self::interactions::{Interactions, LocalInteractions};
 
 mod energy;
 pub use self::energy::EnergyEvaluator;

--- a/src/core/src/sys/mod.rs
+++ b/src/core/src/sys/mod.rs
@@ -7,7 +7,7 @@ mod config;
 pub use self::config::*;
 
 mod system;
-pub use self::system::System;
+pub use self::system::{System, LocalPotentials};
 
 mod interactions;
 use self::interactions::{Interactions, LocalInteractions};

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -150,14 +150,14 @@ impl System {
     pub fn add_pair_potential(&mut self, i: &str, j: &str, potential: PairInteraction) {
         let kind_i = self.get_kind(i);
         let kind_j = self.get_kind(j);
-        self.interactions.add_pair(kind_i, kind_j, potential)
+        self.interactions.local.add_pair(kind_i, kind_j, potential)
     }
 
     /// Add the `potential` bonded interaction for the pair `(i, j)`
     pub fn add_bond_potential(&mut self, i: &str, j: &str, potential: Box<BondPotential>) {
         let kind_i = self.get_kind(i);
         let kind_j = self.get_kind(j);
-        self.interactions.add_bond(kind_i, kind_j, potential)
+        self.interactions.local.add_bond(kind_i, kind_j, potential)
     }
 
     /// Add the `potential` angle interaction for the angle `(i, j, k)`
@@ -165,7 +165,7 @@ impl System {
         let kind_i = self.get_kind(i);
         let kind_j = self.get_kind(j);
         let kind_k = self.get_kind(k);
-        self.interactions.add_angle(kind_i, kind_j, kind_k, potential)
+        self.interactions.local.add_angle(kind_i, kind_j, kind_k, potential)
     }
 
     /// Add the `potential` dihedral interaction for the dihedral angle `(i, j,
@@ -175,7 +175,7 @@ impl System {
         let kind_j = self.get_kind(j);
         let kind_k = self.get_kind(k);
         let kind_m = self.get_kind(m);
-        self.interactions.add_dihedral(kind_i, kind_j, kind_k, kind_m, potential)
+        self.interactions.local.add_dihedral(kind_i, kind_j, kind_k, kind_m, potential)
     }
 
     /// Set the coulombic interaction for all pairs to `potential`
@@ -193,7 +193,7 @@ impl System {
     pub fn pair_potentials(&self, i: usize, j: usize) -> &[PairInteraction] {
         let kind_i = self.particle(i).kind;
         let kind_j = self.particle(j).kind;
-        let pairs = self.interactions.pairs(kind_i, kind_j);
+        let pairs = self.interactions.local.pairs(kind_i, kind_j);
         if pairs.is_empty() {
             warn_once!(
                 "No potential defined for the pair ({}, {})",
@@ -213,7 +213,7 @@ impl System {
     pub fn bond_potentials(&self, i: usize, j: usize) -> &[Box<BondPotential>] {
         let kind_i = self.particle(i).kind;
         let kind_j = self.particle(j).kind;
-        let bonds = self.interactions.bonds(kind_i, kind_j);
+        let bonds = self.interactions.local.bonds(kind_i, kind_j);
         if bonds.is_empty() {
             warn_once!(
                 "No potential defined for the bond ({}, {})",
@@ -229,7 +229,7 @@ impl System {
         let kind_i = self.particle(i).kind;
         let kind_j = self.particle(j).kind;
         let kind_k = self.particle(k).kind;
-        let angles = self.interactions.angles(kind_i, kind_j, kind_k);
+        let angles = self.interactions.local.angles(kind_i, kind_j, kind_k);
         if angles.is_empty() {
             warn_once!(
                 "No potential defined for the angle ({}, {}, {})",

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -38,6 +38,10 @@ pub struct System {
     external_temperature: Option<f64>,
 }
 
+
+/// Struct that can be used to query the
+/// local interactions. As opposed to the `System`,
+/// it is `Sync`.
 #[derive(Copy, Clone)]
 pub struct LocalPotentials<'a>(&'a Configuration, &'a LocalInteractions);
 

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -10,7 +10,7 @@ use energy::{PairInteraction, BondPotential, AnglePotential, DihedralPotential};
 use energy::{GlobalPotential, CoulombicPotential};
 
 use sys::{Configuration, Particle, ParticleKind, UnitCell};
-use sys::{Composition, Interactions, EnergyEvaluator};
+use sys::{Composition, Interactions, LocalInteractions, EnergyEvaluator};
 
 /// The `System` type hold all the data about a simulated system.
 ///
@@ -37,6 +37,9 @@ pub struct System {
     /// Externally managed temperature for the system
     external_temperature: Option<f64>,
 }
+
+#[derive(Copy, Clone)]
+pub struct LocalPotentials<'a>(&'a Configuration, &'a LocalInteractions);
 
 impl System {
     /// Create a new empty `System`
@@ -119,7 +122,6 @@ impl System {
     }
 
 
-
     /// Guess the bonds in the configuration using the chemfiles algorithm.
     ///
     /// This function removes any existing bond, and tries to guess them using
@@ -188,19 +190,16 @@ impl System {
         self.interactions.globals.push(potential);
     }
 
+    /// Get a provider form which one can query local potentials
+    pub fn local_potentials(&self) -> LocalPotentials {
+        LocalPotentials(&self.configuration, &self.interactions.local)
+    }
+
     /// Get the list of pair potential acting between the particles at indexes
     /// `i` and `j`.
+    #[inline]
     pub fn pair_potentials(&self, i: usize, j: usize) -> &[PairInteraction] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
-        let pairs = self.interactions.local.pairs(kind_i, kind_j);
-        if pairs.is_empty() {
-            warn_once!(
-                "No potential defined for the pair ({}, {})",
-                self.particle(i).name(), self.particle(j).name()
-            );
-        }
-        return pairs;
+        self.local_potentials().pairs(i, j)
     }
 
     /// Get read-only access to the interactions for this system
@@ -210,52 +209,23 @@ impl System {
 
     /// Get the list of bonded potential acting between the particles at indexes
     /// `i` and `j`.
+    #[inline]
     pub fn bond_potentials(&self, i: usize, j: usize) -> &[Box<BondPotential>] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
-        let bonds = self.interactions.local.bonds(kind_i, kind_j);
-        if bonds.is_empty() {
-            warn_once!(
-                "No potential defined for the bond ({}, {})",
-                self.particle(i).name(), self.particle(j).name()
-            );
-        }
-        return bonds;
+        self.local_potentials().bonds(i, j)
     }
 
     /// Get the list of angle interaction acting between the particles at
     /// indexes `i`, `j` and `k`.
+    #[inline]
     pub fn angle_potentials(&self, i: usize, j: usize, k: usize) -> &[Box<AnglePotential>] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
-        let kind_k = self.particle(k).kind;
-        let angles = self.interactions.local.angles(kind_i, kind_j, kind_k);
-        if angles.is_empty() {
-            warn_once!(
-                "No potential defined for the angle ({}, {}, {})",
-                self.particle(i).name(), self.particle(j).name(),
-                self.particle(k).name()
-            );
-        }
-        return angles;
+        self.local_potentials().angles(i, j, k)
     }
 
     /// Get the list of dihedral angles interaction acting between the particles
     /// at indexes `i`, `j`, `k` and `m`.
+    #[inline]
     pub fn dihedral_potentials(&self, i: usize, j: usize, k: usize, m: usize) -> &[Box<DihedralPotential>] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
-        let kind_k = self.particle(k).kind;
-        let kind_m = self.particle(m).kind;
-        let dihedrals = self.interactions.dihedrals(kind_i, kind_j, kind_k, kind_m);
-        if dihedrals.is_empty() {
-            warn_once!(
-                "No potential defined for the dihedral angle ({}, {}, {}, {})",
-                self.particle(i).name(), self.particle(j).name(),
-                self.particle(k).name(), self.particle(m).name()
-            );
-        }
-        return dihedrals;
+        self.local_potentials().dihedrals(i, j, k, m)
     }
 
     /// Get the coulombic interaction for the system
@@ -274,6 +244,73 @@ impl System {
     }
 }
 
+impl<'a> LocalPotentials<'a> {
+    /// Get the list of pair potential acting between the particles at indexes
+   /// `i` and `j`.
+    pub fn pairs(self, i: usize, j: usize) -> &'a [PairInteraction] {
+        let kind_i = self.0.particle(i).kind;
+        let kind_j = self.0.particle(j).kind;
+        let pairs = self.1.pairs(kind_i, kind_j);
+        if pairs.is_empty() {
+            warn_once!(
+                "No potential defined for the pair ({}, {})",
+                self.0.particle(i).name(), self.0.particle(j).name()
+            );
+        }
+        return pairs;
+    }
+
+    /// Get the list of bonded potential acting between the particles at indexes
+    /// `i` and `j`.
+    pub fn bonds(self, i: usize, j: usize) -> &'a [Box<BondPotential>] {
+        let kind_i = self.0.particle(i).kind;
+        let kind_j = self.0.particle(j).kind;
+        let bonds = self.1.bonds(kind_i, kind_j);
+        if bonds.is_empty() {
+            warn_once!(
+                "No potential defined for the bond ({}, {})",
+                self.0.particle(i).name(), self.0.particle(j).name()
+            );
+        }
+        return bonds;
+    }
+
+    /// Get the list of angle interaction acting between the particles at
+    /// indexes `i`, `j` and `k`.
+    pub fn angles(self, i: usize, j: usize, k: usize) -> &'a [Box<AnglePotential>] {
+        let kind_i = self.0.particle(i).kind;
+        let kind_j = self.0.particle(j).kind;
+        let kind_k = self.0.particle(k).kind;
+        let angles = self.1.angles(kind_i, kind_j, kind_k);
+        if angles.is_empty() {
+            warn_once!(
+                "No potential defined for the angle ({}, {}, {})",
+                self.0.particle(i).name(), self.0.particle(j).name(),
+                self.0.particle(k).name()
+            );
+        }
+        return angles;
+    }
+
+    /// Get the list of dihedral angles interaction acting between the particles
+    /// at indexes `i`, `j`, `k` and `m`.
+    pub fn dihedrals(self, i: usize, j: usize, k: usize, m: usize) -> &'a [Box<DihedralPotential>] {
+        let kind_i = self.0.particle(i).kind;
+        let kind_j = self.0.particle(j).kind;
+        let kind_k = self.0.particle(k).kind;
+        let kind_m = self.0.particle(m).kind;
+        let dihedrals = self.1.dihedrals(kind_i, kind_j, kind_k, kind_m);
+        if dihedrals.is_empty() {
+            warn_once!(
+                "No potential defined for the dihedral angle ({}, {}, {}, {})",
+                self.0.particle(i).name(), self.0.particle(j).name(),
+                self.0.particle(k).name(), self.0.particle(m).name()
+            );
+        }
+        return dihedrals;
+    }
+}
+
 use sys::compute::Compute;
 use sys::compute::{PotentialEnergy, KineticEnergy, TotalEnergy};
 use sys::compute::Forces;
@@ -285,11 +322,11 @@ use sys::compute::{StressAtTemperature, PressureAtTemperature};
 /// Functions to get physical properties of a system.
 impl System {
     /// Get the kinetic energy of the system.
-    pub fn kinetic_energy(&self) -> f64 {KineticEnergy.compute(self)}
+    pub fn kinetic_energy(&self) -> f64 { KineticEnergy.compute(self) }
     /// Get the potential energy of the system.
-    pub fn potential_energy(&self) -> f64 {PotentialEnergy.compute(self)}
+    pub fn potential_energy(&self) -> f64 { PotentialEnergy.compute(self) }
     /// Get the total energy of the system.
-    pub fn total_energy(&self) -> f64 {TotalEnergy.compute(self)}
+    pub fn total_energy(&self) -> f64 { TotalEnergy.compute(self) }
 
     /// Get the temperature of the system.
     pub fn temperature(&self) -> f64 {


### PR DESCRIPTION
This PR:
* introduces a separation between `Interactions` and `LocalInteractions`, the latter containing only the pair, bond, angle and dihedral potentials (and thus being `Sync`)
* adapts the `System` to this change
* removes the `RwLock` on `Ewald`

Maybe the `Ewald`/`SharedEwald` separation does not make that much sense anymore ? Should I remove it and only hide `rho` and `fourier_phases` behind `RefCell`s ?