### PR TITLE
Switch particle storage to struct of array

### DIFF
--- a/benches/argon.rs
+++ b/benches/argon.rs
@@ -45,7 +45,7 @@ fn cache_move_particle(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(654646);
 
     let i: usize = rng.gen_range(0, system.size());
-    let mut delta = system.particle(i).position;
+    let mut delta = system.particles().position[i];
     delta += Vector3D::new(rng.gen(), rng.gen(), rng.gen());
 
     bencher.iter(||{

--- a/benches/nacl.rs
+++ b/benches/nacl.rs
@@ -85,7 +85,7 @@ fn cache_move_particle_ewald(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(41201154);
 
     let i: usize = rng.gen_range(0, system.size());
-    let mut delta = system.particle(i).position;
+    let mut delta = system.particles().position[i];
     delta += Vector3D::new(rng.gen(), rng.gen(), rng.gen());
 
     bencher.iter(||{
@@ -103,7 +103,7 @@ fn cache_move_particle_wolf(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(474114);
 
     let i: usize = rng.gen_range(0, system.size());
-    let mut delta = system.particle(i).position;
+    let mut delta = system.particles().position[i];
     delta += Vector3D::new(rng.gen(), rng.gen(), rng.gen());
 
     bencher.iter(||{

--- a/benches/propane.rs
+++ b/benches/propane.rs
@@ -45,9 +45,9 @@ fn cache_move_particles(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(84541545);
 
     let molecule = rng.choose(system.molecules()).unwrap();
+    let indexes = molecule.into_iter();
     let mut delta = vec![];
-    for i in molecule {
-        let position = system.particle(i).position;
+    for position in &system.particles().position[indexes] {
         delta.push(position + Vector3D::new(rng.gen(), rng.gen(), rng.gen()));
     }
 
@@ -64,8 +64,9 @@ fn cache_move_all_rigid_molecules(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(7012121);
     for molecule in system.molecules().to_owned() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
-        for i in molecule {
-            system.particle_mut(i).position += delta;
+        let indexes = molecule.into_iter();
+        for position in &mut system.particles_mut().position[indexes] {
+            *position += delta;
         }
     }
 

--- a/benches/water.rs
+++ b/benches/water.rs
@@ -95,9 +95,9 @@ fn cache_move_particles_wolf(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(454548784);
 
     let molecule = rng.choose(system.molecules()).unwrap();
+    let indexes = molecule.into_iter();
     let mut delta = vec![];
-    for i in molecule {
-        let position = system.particle(i).position;
+    for position in &system.particles().position[indexes] {
         delta.push(position + Vector3D::new(rng.gen(), rng.gen(), rng.gen()));
     }
 
@@ -116,9 +116,9 @@ fn cache_move_particles_ewald(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(9886565);
 
     let molecule = rng.choose(system.molecules()).unwrap();
+    let indexes = molecule.into_iter();
     let mut delta = vec![];
-    for i in molecule {
-        let position = system.particle(i).position;
+    for position in &system.particles().position[indexes] {
         delta.push(position + Vector3D::new(rng.gen(), rng.gen(), rng.gen()));
     }
 
@@ -137,8 +137,9 @@ fn cache_move_all_rigid_molecules_wolf(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(3);
     for molecule in system.molecules().to_owned() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
-        for i in molecule {
-            system.particle_mut(i).position += delta;
+        let indexes = molecule.into_iter();
+        for position in &mut system.particles_mut().position[indexes] {
+            *position += delta;
         }
     }
 
@@ -157,8 +158,9 @@ fn cache_move_all_rigid_molecules_ewald(bencher: &mut Bencher) {
     let mut rng = utils::get_rng(2121);
     for molecule in system.molecules().to_owned() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
-        for i in molecule {
-            system.particle_mut(i).position += delta;
+        let indexes = molecule.into_iter();
+        for position in &mut system.particles_mut().position[indexes] {
+            *position += delta;
         }
     }
 

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -5,7 +5,7 @@
 extern crate lumol;
 extern crate lumol_input as input;
 
-use lumol::sys::{Molecule, Particle, TrajectoryBuilder, UnitCell};
+use lumol::sys::{Molecule, Particle, ParticleVec, TrajectoryBuilder, UnitCell};
 use lumol::sys::{read_molecule, molecule_type};
 use lumol::sim::Simulation;
 use lumol::sim::mc::{MonteCarlo, Translate, Rotate};
@@ -30,7 +30,7 @@ fn main() {
     let co2 = {
         // We can read files to get molecule type
         let (molecule, atoms) = read_molecule("data/CO2.xyz").unwrap();
-        molecule_type(&molecule, &atoms)
+        molecule_type(&molecule, atoms.as_slice())
     };
     let h2o = {
         // Or define a new molecule by hand
@@ -41,7 +41,12 @@ fn main() {
         molecule.add_bond(0, 1);
         molecule.add_bond(1, 2);
 
-        molecule_type(&molecule, &[Particle::new("H"), Particle::new("O"), Particle::new("H")])
+        let mut atoms = ParticleVec::new();
+        atoms.push(Particle::new("H"));
+        atoms.push(Particle::new("O"));
+        atoms.push(Particle::new("H"));
+
+        molecule_type(&molecule, atoms.as_slice())
     };
 
     let mut mc = MonteCarlo::new(units::from(500.0, "K").unwrap());

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -43,12 +43,10 @@ fn get_system() -> System {
     system.add_angle_potential("H", "O", "H", angle);
 
     // Set charges
-    let h = 0.42380;
-    let o = - 2.0 * h;
     for particle in system.particles_mut() {
         match particle.name.as_ref() {
-            "H" => particle.charge = h,
-            "O" => particle.charge = o,
+            "H" => *particle.charge = 0.42380,
+            "O" => *particle.charge = -2.0 * 0.42380,
             _ => panic!("Unknown particle name in charge setting."),
         }
     }

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -46,7 +46,7 @@ fn get_system() -> System {
     let h = 0.42380;
     let o = - 2.0 * h;
     for particle in system.particles_mut() {
-        match particle.name() {
+        match particle.name.as_ref() {
             "H" => particle.charge = h,
             "O" => particle.charge = o,
             _ => panic!("Unknown particle name in charge setting."),

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = "0.1"
 rayon = "0.8"
 thread_local = "0.3"
 caldyn = "0.4"
+itertools = "0.6"
 
 [dev-dependencies]
 tempfile = "2.1"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -25,6 +25,7 @@ rayon = "0.8"
 thread_local = "0.3"
 caldyn = "0.4"
 itertools = "0.6"
+soa_derive = "0.4"
 
 [dev-dependencies]
 tempfile = "2.1"

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -838,9 +838,9 @@ mod tests {
         assert!(system.molecules().len() == 1);
 
         for particle in system.particles_mut() {
-            if particle.name() == "O" {
+            if particle.name == "O" {
                 particle.charge = -0.8476;
-            } else if particle.name() == "H" {
+            } else if particle.name == "H" {
                 particle.charge = 0.4238;
             }
         }
@@ -1079,9 +1079,9 @@ mod tests {
             assert!(system.molecules().len() == 2);
 
             for particle in system.particles_mut() {
-                if particle.name() == "O" {
+                if particle.name == "O" {
                     particle.charge = -0.8476;
-                } else if particle.name() == "H" {
+                } else if particle.name == "H" {
                     particle.charge = 0.4238;
                 }
             }

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -335,9 +335,9 @@ mod tests {
             assert!(system.molecules().len() == 2);
 
             for particle in system.particles_mut() {
-                if particle.name() == "O" {
+                if particle.name == "O" {
                     particle.charge = -0.8476;
-                } else if particle.name() == "H" {
+                } else if particle.name == "H" {
                     particle.charge = 0.4238;
                 }
             }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -42,6 +42,8 @@ extern crate log_once;
 extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate itertools;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -44,6 +44,8 @@ extern crate bitflags;
 extern crate lazy_static;
 #[macro_use]
 extern crate itertools;
+#[macro_use]
+extern crate soa_derive;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/core/src/out/custom.rs
+++ b/src/core/src/out/custom.rs
@@ -13,6 +13,7 @@ use caldyn::Error as CaldynError;
 
 use super::Output;
 use sys::System;
+use types::Zero;
 use units;
 
 /// Possible causes of error when using a custom output
@@ -137,17 +138,18 @@ impl FormatArgs {
             // Get unit conversion factor firsts
             units::FACTORS.get(name).cloned().or_else(|| {
                 macro_rules! get_particle_data {
-                    ($index: ident, $callback: expr) => (
+                    ($index: ident, $data: ident) => (
                         system.particles()
-                              .nth($index)
-                              .map($callback)
+                              .$data
+                              .get($index)
+                              .cloned()
                               .unwrap_or_else(|| {
                                   warn_once!(
                                       "index out of bound in custom output: \
                                       index is {}, but we only have {} atoms",
                                       $index, system.size()
                                   );
-                                  return 0.0;
+                                  return Zero::zero();
                               })
                     );
                 }
@@ -156,16 +158,16 @@ impl FormatArgs {
                     let (name, index) = parse_index(name);
                     match name {
                         // position
-                        "x" => Some(get_particle_data!(index, |p| p.position[0])),
-                        "y" => Some(get_particle_data!(index, |p| p.position[1])),
-                        "z" => Some(get_particle_data!(index, |p| p.position[2])),
+                        "x" => Some(get_particle_data!(index, position)[0]),
+                        "y" => Some(get_particle_data!(index, position)[1]),
+                        "z" => Some(get_particle_data!(index, position)[2]),
                         // velocity
-                        "vx" => Some(get_particle_data!(index, |p| p.velocity[0])),
-                        "vy" => Some(get_particle_data!(index, |p| p.velocity[1])),
-                        "vz" => Some(get_particle_data!(index, |p| p.velocity[2])),
+                        "vx" => Some(get_particle_data!(index, velocity)[0]),
+                        "vy" => Some(get_particle_data!(index, velocity)[1]),
+                        "vz" => Some(get_particle_data!(index, velocity)[2]),
                         // other atomic properties
-                        "mass" => Some(get_particle_data!(index, |p| p.mass)),
-                        "charge" => Some(get_particle_data!(index, |p| p.charge)),
+                        "mass" => Some(get_particle_data!(index, mass)),
+                        "charge" => Some(get_particle_data!(index, charge)),
                         _ => None
                     }
                 } else {

--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -89,8 +89,8 @@ impl MCMove for Resize {
             let old_com = system.molecule_com(mi);
             let frac_com = system.cell.fractional(&old_com);
             let delta_com = system.cell.cartesian(&frac_com) - old_com;
-            for pi in molecule.iter() {
-                system.particle_mut(pi).position += delta_com;
+            for position in &mut system.particles_mut().position[molecule.iter()] {
+                *position += delta_com;
             }
         }
         true

--- a/src/core/src/sim/mc/moves/rotate.rs
+++ b/src/core/src/sim/mc/moves/rotate.rs
@@ -86,12 +86,9 @@ impl MCMove for Rotate {
         let theta = self.range.sample(rng);
 
         // get indices of particles of selected molecule
-        let molecule = system.molecule(self.molid);
+        let indexes = system.molecule(self.molid).iter();
         // store positions of selected molecule
-        self.newpos.clear();
-        for pi in molecule.iter() {
-            self.newpos.push(system.particle(pi).position);
-        }
+        self.newpos = system.particles().position[indexes].to_vec();
         // get center-of-mass of molecule
         let com = system.molecule_com(self.molid);
         rotate_around_axis(&mut self.newpos, com, axis, theta);
@@ -105,8 +102,10 @@ impl MCMove for Rotate {
     }
 
     fn apply(&mut self, system: &mut System) {
-        for (i, pi) in system.molecule(self.molid).iter().enumerate() {
-            system.particle_mut(pi).position = self.newpos[i];
+        let indexes = system.molecule(self.molid).iter();
+        let positions = &mut system.particles_mut().position[indexes];
+        for (position, newpos) in izip!(positions, &self.newpos) {
+            *position = *newpos;
         }
     }
 

--- a/src/core/src/sim/md/controls.rs
+++ b/src/core/src/sim/md/controls.rs
@@ -193,8 +193,6 @@ mod tests {
     use super::*;
     use sys::{System, UnitCell, Particle};
     use sys::veloc::{BoltzmannVelocities, InitVelocities};
-    // use types::*;
-    use sim::Alternator;
     use utils::system_from_xyz;
 
     fn testing_system() -> System {
@@ -268,19 +266,7 @@ mod tests {
         Ag 1 1 1 1 0 0
         ");
 
-        let mut control = Alternator::new(4, RemoveTranslation::new());
-
-        // The three first controls do nothing
-        let vel_0 = system.particle(0).velocity;
-        let vel_1 = system.particle(1).velocity;
-        for _ in 0..3 {
-            control.control(&mut system);
-            assert_ulps_eq!(system.particle(0).velocity, vel_0);
-            assert_ulps_eq!(system.particle(1).velocity, vel_1);
-        }
-
-        // The fourth one removes global translation
-        control.control(&mut system);
+        RemoveTranslation::new().control(&mut system);
         assert_ulps_eq!(system.particle(0).velocity, Vector3D::new(0.0, 1.0, 0.0));
         assert_ulps_eq!(system.particle(1).velocity, Vector3D::new(0.0, -1.0, 0.0));
     }
@@ -293,19 +279,7 @@ mod tests {
         Ag 1 0 0 0 -1 2
         ");
 
-        let mut control = Alternator::new(4, RemoveRotation::new());
-
-        // The three first controls do nothing
-        let vel_0 = system.particle(0).velocity;
-        let vel_1 = system.particle(1).velocity;
-        for _ in 0..3 {
-            control.control(&mut system);
-            assert_ulps_eq!(system.particle(0).velocity, vel_0);
-            assert_ulps_eq!(system.particle(1).velocity, vel_1);
-        }
-
-        // The fourth one removes global rotation
-        control.control(&mut system);
+        RemoveRotation::new().control(&mut system);
         assert_ulps_eq!(system.particle(0).velocity, Vector3D::new(0.0, 0.0, 1.0));
         assert_ulps_eq!(system.particle(1).velocity, Vector3D::new(0.0, 0.0, 1.0));
     }

--- a/src/core/src/sim/simulations.rs
+++ b/src/core/src/sim/simulations.rs
@@ -119,11 +119,11 @@ impl Simulation {
 
     /// Perform some sanity checks on the system
     fn sanity_check(&self, system: &System) {
-        for particle in system.particles() {
+        for position in system.particles().position {
             // The value of 1e6 A should be a good enough threshold. Even with
             // big boxes (100 A), and going through the boxes multiple time,
             // the particles positions should stay bellow this point.
-            if any(&particle.position, |x| x.abs() > 1e6) {
+            if any(position, |x| x.abs() > 1e6) {
                 warn!(
                     "Some particles have moved very far from the origin, \
                     the simulation might be exploding"
@@ -132,9 +132,11 @@ impl Simulation {
                 // problem was found
                 return;
             }
+        }
 
+        for velocity in system.particles().velocity {
             // Velocity threshold is 1000 A / fs
-            if any(&particle.velocity, |x| x.abs() > 1000.0) {
+            if any(velocity, |x| x.abs() > 1000.0) {
                 warn!(
                     "Some particles have a very high velocity, \
                     the simulation might be exploding"

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -406,9 +406,9 @@ mod tests {
         system.set_coulomb_potential(Box::new(Wolf::new(8.0)));
 
         for atom in system.particles_mut() {
-            if atom.name() == "O" {
+            if atom.name == "O" {
                 atom.charge = -0.5;
-            } else if atom.name() == "H" {
+            } else if atom.name == "H" {
                 atom.charge = 0.5;
             }
         }

--- a/src/core/src/sys/chfl.rs
+++ b/src/core/src/sys/chfl.rs
@@ -142,7 +142,7 @@ pub trait ToChemfiles {
 impl ToChemfiles for Particle {
     type Output = chemfiles::Atom;
     fn to_chemfiles(&self) -> TrajectoryResult<chemfiles::Atom> {
-        let mut atom = try!(chemfiles::Atom::new(self.name()));
+        let mut atom = try!(chemfiles::Atom::new(&*self.name));
         try!(atom.set_mass(self.mass));
         return Ok(atom);
     }
@@ -534,9 +534,9 @@ H      2.172669     -0.348524    0.000051
 
         assert!(molecule.dihedrals().is_empty());
 
-        assert_eq!(atoms[0].name(), "O");
-        assert_eq!(atoms[1].name(), "H");
-        assert_eq!(atoms[2].name(), "H");
+        assert_eq!(atoms[0].name, "O");
+        assert_eq!(atoms[1].name, "H");
+        assert_eq!(atoms[2].name, "H");
 
         // This is only a simple regression test on the moltype function. Feel
         // free to change the value if the molecule type algorithm change.

--- a/src/core/src/sys/config/configuration.rs
+++ b/src/core/src/sys/config/configuration.rs
@@ -573,9 +573,9 @@ mod tests {
         configuration.add_particle(particle("H"));
 
         assert_eq!(configuration.size(), 3);
-        assert_eq!(configuration.particle(0).name(), "O");
-        assert_eq!(configuration.particle(1).name(), "H");
-        assert_eq!(configuration.particle(2).name(), "H");
+        assert_eq!(configuration.particle(0).name, "O");
+        assert_eq!(configuration.particle(1).name, "H");
+        assert_eq!(configuration.particle(2).name, "H");
     }
 
     #[test]

--- a/src/core/src/sys/config/mod.rs
+++ b/src/core/src/sys/config/mod.rs
@@ -8,6 +8,9 @@ pub use self::periodic::{PeriodicTable, ElementData};
 
 mod particles;
 pub use self::particles::{Particle, ParticleKind};
+pub use self::particles::{ParticleVec, ParticleSlice, ParticleSliceMut};
+pub use self::particles::{ParticleRef, ParticleRefMut};
+pub use self::particles::zip_particle;
 
 mod composition;
 pub use self::composition::Composition;

--- a/src/core/src/sys/config/molecules.rs
+++ b/src/core/src/sys/config/molecules.rs
@@ -9,7 +9,7 @@ use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
 
 use types::Array2;
-use sys::{Particle, Bond, Angle, Dihedral, BondDistance};
+use sys::{ParticleSlice, Bond, Angle, Dihedral, BondDistance};
 
 #[derive(Debug, Clone)]
 /// A molecule is the basic building block for a topology. It contains data
@@ -309,12 +309,12 @@ impl Molecule {
 /// Get the molecule type of the given `molecule` containing the `particles`.
 /// This type can be used to identify all the molecules containing the same
 /// bonds and particles (see `System::molecule_type` for more information).
-pub fn molecule_type(molecule: &Molecule, particles: &[Particle]) -> u64 {
+pub fn molecule_type(molecule: &Molecule, particles: ParticleSlice) -> u64 {
     assert_eq!(particles.len(), molecule.size());
     let mut hasher = DefaultHasher::new();
     molecule.cached_hash.hash(&mut hasher);
-    for particle in particles {
-        particle.name.hash(&mut hasher);
+    for name in particles.name {
+        name.hash(&mut hasher);
     }
     hasher.finish()
 }

--- a/src/core/src/sys/config/molecules.rs
+++ b/src/core/src/sys/config/molecules.rs
@@ -314,7 +314,7 @@ pub fn molecule_type(molecule: &Molecule, particles: &[Particle]) -> u64 {
     let mut hasher = DefaultHasher::new();
     molecule.cached_hash.hash(&mut hasher);
     for particle in particles {
-        particle.name().hash(&mut hasher);
+        particle.name.hash(&mut hasher);
     }
     hasher.finish()
 }

--- a/src/core/src/sys/config/particles.rs
+++ b/src/core/src/sys/config/particles.rs
@@ -1,7 +1,5 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
-
-//! `Particle` type and manipulation.
 use types::{Vector3D, Zero};
 use sys::PeriodicTable;
 
@@ -27,22 +25,25 @@ impl fmt::Display for ParticleKind {
 
 /// The Particle type hold basic data about a particle in the system. It is self
 /// contained, so that it will be easy to send data between parallels processes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, StructOfArray)]
+#[soa_derive = "Clone, Debug"]
 pub struct Particle {
     /// Particle name.
     pub name: String,
     /// Particle kind, an index for potentials lookup
-    pub(in ::sys) kind: ParticleKind,
-    /// Particle mass
-    pub mass: f64,
+    pub kind: ParticleKind,
     /// Particle charge
     pub charge: f64,
+    /// Particle mass
+    #[soa_derive(zip)]
+    pub mass: f64,
     /// Particle positions
+    #[soa_derive(zip)]
     pub position: Vector3D,
     /// Particle velocity, if needed
+    #[soa_derive(zip)]
     pub velocity: Vector3D,
 }
-
 
 impl Particle {
     /// Create a new `Particle` from a `name`

--- a/src/core/src/sys/config/particles.rs
+++ b/src/core/src/sys/config/particles.rs
@@ -29,9 +29,8 @@ impl fmt::Display for ParticleKind {
 /// contained, so that it will be easy to send data between parallels processes.
 #[derive(Clone, Debug)]
 pub struct Particle {
-    /// Particle name. This one is not public, as we always want to get &str,
-    /// and to use either `String` of `&str` to set it.
-    name: String,
+    /// Particle name.
+    pub name: String,
     /// Particle kind, an index for potentials lookup
     pub(in ::sys) kind: ParticleKind,
     /// Particle mass
@@ -67,16 +66,6 @@ impl Particle {
             velocity: Vector3D::zero()
         }
     }
-
-    /// Get the particle name
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Set the particle name to `name`
-    pub fn set_name<'a, S>(&mut self, name: S) where S: Into<&'a str> {
-        self.name = String::from(name.into());
-    }
 }
 
 #[cfg(test)]
@@ -92,23 +81,20 @@ mod tests {
 
     #[test]
     fn name() {
-        let mut particle = Particle::new("");
-        assert_eq!(particle.name(), "");
+        let particle = Particle::new("");
+        assert_eq!(particle.name, "");
 
         assert_eq!(particle.mass, 0.0);
         assert_eq!(particle.charge, 0.0);
         assert_eq!(particle.kind, ParticleKind::invalid());
         assert_eq!(particle.position, Vector3D::new(0.0, 0.0, 0.0));
         assert_eq!(particle.velocity, Vector3D::new(0.0, 0.0, 0.0));
-
-        particle.set_name("H");
-        assert_eq!(particle.name(), "H");
     }
 
     #[test]
     fn with_position() {
         let particle = Particle::with_position("", Vector3D::new(1.0, 2.0, 3.0));
-        assert_eq!(particle.name(), "");
+        assert_eq!(particle.name, "");
         assert_eq!(particle.position, Vector3D::new(1.0, 2.0, 3.0));
 
         assert_eq!(particle.mass, 0.0);

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -75,7 +75,7 @@ impl System {
     /// Insert a particle at the end of the internal list.
     pub fn add_particle(&mut self, mut particle: Particle) {
         if particle.kind == ParticleKind::invalid() {
-            particle.kind = self.get_kind(particle.name());
+            particle.kind = self.get_kind(&particle.name);
         }
         self.configuration.add_particle(particle);
     }
@@ -197,7 +197,7 @@ impl System {
         if pairs.is_empty() {
             warn_once!(
                 "No potential defined for the pair ({}, {})",
-                self.particle(i).name(), self.particle(j).name()
+                self.particle(i).name, self.particle(j).name
             );
         }
         return pairs;
@@ -217,7 +217,7 @@ impl System {
         if bonds.is_empty() {
             warn_once!(
                 "No potential defined for the bond ({}, {})",
-                self.particle(i).name(), self.particle(j).name()
+                self.particle(i).name, self.particle(j).name
             );
         }
         return bonds;
@@ -233,8 +233,8 @@ impl System {
         if angles.is_empty() {
             warn_once!(
                 "No potential defined for the angle ({}, {}, {})",
-                self.particle(i).name(), self.particle(j).name(),
-                self.particle(k).name()
+                self.particle(i).name, self.particle(j).name,
+                self.particle(k).name
             );
         }
         return angles;
@@ -251,8 +251,8 @@ impl System {
         if dihedrals.is_empty() {
             warn_once!(
                 "No potential defined for the dihedral angle ({}, {}, {}, {})",
-                self.particle(i).name(), self.particle(j).name(),
-                self.particle(k).name(), self.particle(m).name()
+                self.particle(i).name, self.particle(j).name,
+                self.particle(k).name, self.particle(m).name
             );
         }
         return dihedrals;

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -84,8 +84,8 @@ impl System {
     pub fn composition(&self) -> Composition {
         let mut composition = Composition::new();
         composition.resize(self.kinds.len());
-        for particle in self.particles() {
-            composition[particle.kind] += 1;
+        for &kind in self.particles().kind {
+            composition[kind] += 1;
         }
         return composition;
     }
@@ -191,13 +191,13 @@ impl System {
     /// Get the list of pair potential acting between the particles at indexes
     /// `i` and `j`.
     pub fn pair_potentials(&self, i: usize, j: usize) -> &[PairInteraction] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
+        let kind_i = self.particles().kind[i];
+        let kind_j = self.particles().kind[j];
         let pairs = self.interactions.pairs(kind_i, kind_j);
         if pairs.is_empty() {
             warn_once!(
                 "No potential defined for the pair ({}, {})",
-                self.particle(i).name, self.particle(j).name
+                self.particles().name[i], self.particles().name[j]
             );
         }
         return pairs;
@@ -211,13 +211,13 @@ impl System {
     /// Get the list of bonded potential acting between the particles at indexes
     /// `i` and `j`.
     pub fn bond_potentials(&self, i: usize, j: usize) -> &[Box<BondPotential>] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
+        let kind_i = self.particles().kind[i];
+        let kind_j = self.particles().kind[j];
         let bonds = self.interactions.bonds(kind_i, kind_j);
         if bonds.is_empty() {
             warn_once!(
                 "No potential defined for the bond ({}, {})",
-                self.particle(i).name, self.particle(j).name
+                self.particles().name[i], self.particles().name[j]
             );
         }
         return bonds;
@@ -226,15 +226,15 @@ impl System {
     /// Get the list of angle interaction acting between the particles at
     /// indexes `i`, `j` and `k`.
     pub fn angle_potentials(&self, i: usize, j: usize, k: usize) -> &[Box<AnglePotential>] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
-        let kind_k = self.particle(k).kind;
+        let kind_i = self.particles().kind[i];
+        let kind_j = self.particles().kind[j];
+        let kind_k = self.particles().kind[k];
         let angles = self.interactions.angles(kind_i, kind_j, kind_k);
         if angles.is_empty() {
             warn_once!(
                 "No potential defined for the angle ({}, {}, {})",
-                self.particle(i).name, self.particle(j).name,
-                self.particle(k).name
+                self.particles().name[i], self.particles().name[j],
+                self.particles().name[k]
             );
         }
         return angles;
@@ -243,16 +243,16 @@ impl System {
     /// Get the list of dihedral angles interaction acting between the particles
     /// at indexes `i`, `j`, `k` and `m`.
     pub fn dihedral_potentials(&self, i: usize, j: usize, k: usize, m: usize) -> &[Box<DihedralPotential>] {
-        let kind_i = self.particle(i).kind;
-        let kind_j = self.particle(j).kind;
-        let kind_k = self.particle(k).kind;
-        let kind_m = self.particle(m).kind;
+        let kind_i = self.particles().kind[i];
+        let kind_j = self.particles().kind[j];
+        let kind_k = self.particles().kind[k];
+        let kind_m = self.particles().kind[m];
         let dihedrals = self.interactions.dihedrals(kind_i, kind_j, kind_k, kind_m);
         if dihedrals.is_empty() {
             warn_once!(
                 "No potential defined for the dihedral angle ({}, {}, {}, {})",
-                self.particle(i).name, self.particle(j).name,
-                self.particle(k).name, self.particle(m).name
+                self.particles().name[i], self.particles().name[j],
+                self.particles().name[k], self.particles().name[m]
             );
         }
         return dihedrals;
@@ -391,9 +391,9 @@ mod tests {
         system.add_particle(Particle::new("O"));
         system.add_particle(Particle::new("H"));
 
-        assert_eq!(system.particle(0).kind, ParticleKind(0));
-        assert_eq!(system.particle(1).kind, ParticleKind(1));
-        assert_eq!(system.particle(2).kind, ParticleKind(0));
+        assert_eq!(system.particles().kind[0], ParticleKind(0));
+        assert_eq!(system.particles().kind[1], ParticleKind(1));
+        assert_eq!(system.particles().kind[2], ParticleKind(0));
     }
 
     #[test]

--- a/src/core/src/sys/veloc.rs
+++ b/src/core/src/sys/veloc.rs
@@ -15,8 +15,8 @@ use sys::System;
 pub fn scale(system: &mut System, temperature: f64) {
     let instant_temperature = system.temperature();
     let factor = f64::sqrt(temperature / instant_temperature);
-    for particle in system.particles_mut() {
-        particle.velocity *= factor;
+    for velocity in system.particles_mut().velocity {
+        *velocity *= factor;
     }
 }
 
@@ -49,11 +49,11 @@ impl BoltzmannVelocities {
 impl InitVelocities for BoltzmannVelocities {
     fn init(&mut self, system: &mut System) {
         for particle in system.particles_mut() {
-            let m_inv = 1.0 / particle.mass;
+            let m_inv = 1.0 / (*particle.mass);
             let x = f64::sqrt(m_inv) * self.dist.sample(&mut self.rng);
             let y = f64::sqrt(m_inv) * self.dist.sample(&mut self.rng);
             let z = f64::sqrt(m_inv) * self.dist.sample(&mut self.rng);
-            particle.velocity = Vector3D::new(x, y, z);
+            *particle.velocity = Vector3D::new(x, y, z);
         }
         scale(system, self.temperature);
     }
@@ -85,11 +85,11 @@ impl UniformVelocities {
 impl InitVelocities for UniformVelocities {
     fn init(&mut self, system: &mut System) {
         for particle in system.particles_mut() {
-            let m_inv = 1.0 / particle.mass;
+            let m_inv = 1.0 / (*particle.mass);
             let x = f64::sqrt(m_inv) * self.dist.sample(&mut self.rng);
             let y = f64::sqrt(m_inv) * self.dist.sample(&mut self.rng);
             let z = f64::sqrt(m_inv) * self.dist.sample(&mut self.rng);
-            particle.velocity = Vector3D::new(x, y, z);
+            *particle.velocity = Vector3D::new(x, y, z);
         }
         scale(system, self.temperature);
     }

--- a/src/core/src/utils/xyz.rs
+++ b/src/core/src/utils/xyz.rs
@@ -66,9 +66,9 @@ mod tests {
         O 0 0 1.5");
         assert_eq!(system.size(), 3);
 
-        assert_eq!(system.particle(0).name(), "O");
-        assert_eq!(system.particle(1).name(), "C");
-        assert_eq!(system.particle(2).name(), "O");
+        assert_eq!(system.particle(0).name, "O");
+        assert_eq!(system.particle(1).name, "C");
+        assert_eq!(system.particle(2).name, "O");
 
         assert_eq!(system.particle(0).position, Vector3D::new(0.0, 0.0, -1.5));
         assert_eq!(system.particle(1).position, Vector3D::new(0.0, 0.0, 0.0));

--- a/src/core/src/utils/xyz.rs
+++ b/src/core/src/utils/xyz.rs
@@ -66,13 +66,13 @@ mod tests {
         O 0 0 1.5");
         assert_eq!(system.size(), 3);
 
-        assert_eq!(system.particle(0).name, "O");
-        assert_eq!(system.particle(1).name, "C");
-        assert_eq!(system.particle(2).name, "O");
+        assert_eq!(system.particles().name[0], "O");
+        assert_eq!(system.particles().name[1], "C");
+        assert_eq!(system.particles().name[2], "O");
 
-        assert_eq!(system.particle(0).position, Vector3D::new(0.0, 0.0, -1.5));
-        assert_eq!(system.particle(1).position, Vector3D::new(0.0, 0.0, 0.0));
-        assert_eq!(system.particle(2).position, Vector3D::new(0.0, 0.0, 1.5));
+        assert_eq!(system.particles().position[0], Vector3D::new(0.0, 0.0, -1.5));
+        assert_eq!(system.particles().position[1], Vector3D::new(0.0, 0.0, 0.0));
+        assert_eq!(system.particles().position[2], Vector3D::new(0.0, 0.0, 1.5));
 
         assert_eq!(system.molecules().len(), 1);
         assert_eq!(system.molecule(0).bonds().len(), 2);
@@ -90,10 +90,10 @@ mod tests {
         assert_eq!(system.molecules().len(), 4);
         assert_eq!(system.cell, UnitCell::cubic(67.0));
 
-        assert_eq!(system.particle(0).position, Vector3D::new(0.0, 0.0, 0.0));
-        assert_eq!(system.particle(1).position, Vector3D::new(1.0, 0.0, 0.0));
-        assert_eq!(system.particle(2).position, Vector3D::new(0.0, 1.0, 0.0));
-        assert_eq!(system.particle(3).position, Vector3D::new(0.0, 0.0, 1.0));
+        assert_eq!(system.particles().position[0], Vector3D::new(0.0, 0.0, 0.0));
+        assert_eq!(system.particles().position[1], Vector3D::new(1.0, 0.0, 0.0));
+        assert_eq!(system.particles().position[2], Vector3D::new(0.0, 1.0, 0.0));
+        assert_eq!(system.particles().position[3], Vector3D::new(0.0, 0.0, 1.0));
     }
 
     #[test]
@@ -109,14 +109,14 @@ mod tests {
         assert_eq!(system.molecules().len(), 4);
         assert_eq!(system.cell, UnitCell::cubic(67.0));
 
-        assert_eq!(system.particle(0).position, Vector3D::new(0.0, 0.0, 0.0));
-        assert_eq!(system.particle(1).position, Vector3D::new(1.0, 0.0, 0.0));
-        assert_eq!(system.particle(2).position, Vector3D::new(0.0, 1.0, 0.0));
-        assert_eq!(system.particle(3).position, Vector3D::new(0.0, 0.0, 1.0));
+        assert_eq!(system.particles().position[0], Vector3D::new(0.0, 0.0, 0.0));
+        assert_eq!(system.particles().position[1], Vector3D::new(1.0, 0.0, 0.0));
+        assert_eq!(system.particles().position[2], Vector3D::new(0.0, 1.0, 0.0));
+        assert_eq!(system.particles().position[3], Vector3D::new(0.0, 0.0, 1.0));
 
-        assert_eq!(system.particle(0).velocity, Vector3D::new(0.0, 0.0, 0.0));
-        assert_eq!(system.particle(1).velocity, Vector3D::new(1.0, 2.0, 3.0));
-        assert_eq!(system.particle(2).velocity, Vector3D::new(0.0, 1.0, 0.0));
-        assert_eq!(system.particle(3).velocity, Vector3D::new(2.0, 2.0, 3.0));
+        assert_eq!(system.particles().velocity[0], Vector3D::new(0.0, 0.0, 0.0));
+        assert_eq!(system.particles().velocity[1], Vector3D::new(1.0, 2.0, 3.0));
+        assert_eq!(system.particles().velocity[2], Vector3D::new(0.0, 1.0, 0.0));
+        assert_eq!(system.particles().velocity[3], Vector3D::new(2.0, 2.0, 3.0));
     }
 }

--- a/src/input/src/interactions/coulomb.rs
+++ b/src/input/src/interactions/coulomb.rs
@@ -81,7 +81,7 @@ impl InteractionsInput {
 
             let mut nchanged = 0;
             for particle in system.particles_mut() {
-                if particle.name() == name {
+                if particle.name == name.as_ref() {
                     particle.charge = charge;
                     nchanged += 1;
                     total_charge += charge;

--- a/src/input/src/interactions/coulomb.rs
+++ b/src/input/src/interactions/coulomb.rs
@@ -81,8 +81,8 @@ impl InteractionsInput {
 
             let mut nchanged = 0;
             for particle in system.particles_mut() {
-                if particle.name == name.as_ref() {
-                    particle.charge = charge;
+                if particle.name == name {
+                    *particle.charge = charge;
                     nchanged += 1;
                     total_charge += charge;
                 }

--- a/src/input/src/simulations/mc.rs
+++ b/src/input/src/simulations/mc.rs
@@ -83,7 +83,7 @@ impl FromTomlWithData for Translate {
             let molfile = try!(extract::str("molecule", config, "Translate move"));
             let molfile = get_input_path(root, molfile);
             let (molecule, atoms) = try!(read_molecule(molfile));
-            let moltype = molecule_type(&molecule, &atoms);
+            let moltype = molecule_type(&molecule, atoms.as_slice());
             Ok(Translate::with_moltype(delta, moltype))
         } else {
             Ok(Translate::new(delta))
@@ -101,7 +101,7 @@ impl FromTomlWithData for Rotate {
             let molfile = try!(extract::str("molecule", config, "Rotate move"));
             let molfile = get_input_path(root, molfile);
             let (molecule, atoms) = try!(read_molecule(molfile));
-            let moltype = molecule_type(&molecule, &atoms);
+            let moltype = molecule_type(&molecule, atoms.as_slice());
             Ok(Rotate::with_moltype(delta, moltype))
         } else {
             Ok(Rotate::new(delta))

--- a/tests/nist-spce.rs
+++ b/tests/nist-spce.rs
@@ -49,9 +49,9 @@ pub fn get_system(path: &str, cutoff: f64) -> System {
     }
 
     for particle in system.particles_mut() {
-        particle.charge = match particle.name.as_ref() {
-            "H" => 0.42380,
-            "O" => -2.0 * 0.42380,
+        match particle.name.as_ref() {
+            "H" => *particle.charge = 0.42380,
+            "O" => *particle.charge = -2.0 * 0.42380,
             other => panic!("Unknown particle name: {}", other)
         }
     }

--- a/tests/nist-spce.rs
+++ b/tests/nist-spce.rs
@@ -49,7 +49,7 @@ pub fn get_system(path: &str, cutoff: f64) -> System {
     }
 
     for particle in system.particles_mut() {
-        particle.charge = match particle.name() {
+        particle.charge = match particle.name.as_ref() {
             "H" => 0.42380,
             "O" => -2.0 * 0.42380,
             other => panic!("Unknown particle name: {}", other)


### PR DESCRIPTION
Fixes #18 

This is a work in progress, it needs benchmarks and feedback on the API!

The meat of the code is not in this repository, but in [soa-derive](https://github.com/lumol-org/soa-derive/).

Most of the changes here consists in `system.particle(i).<xxx> => system.particles().<xxx>[i]`, or handling of the fact that when using `for p in system.particles()`, `p.position` is a reference.

The main issue with the code right now is the fact that the naive looping `for p in system.particles()` might be slower than in previous versions, due to the fact that a new `ParticleRef` is generated at each iteration step. To improve this, I will change the code so that it uses `izip!` iterators and directly access the needed fields.

Please have a look and tell me what you think !
