### PR TITLE
Do not use an alias lumol-core => lumol

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -7,9 +7,6 @@ repository = "https://github.com/lumol-org/lumol"
 readme = "../../README.md"
 license = "BSD-3-Clause"
 
-[lib]
-name = "lumol"
-
 [dependencies]
 chemfiles = "0.7"
 rand = "0.3"
@@ -28,5 +25,6 @@ itertools = "0.6"
 soa_derive = "0.4"
 
 [dev-dependencies]
+lumol = {path = "../.."}
 tempfile = "2.1"
 approx = "0.1.1"

--- a/src/core/src/energy/computations.rs
+++ b/src/core/src/energy/computations.rs
@@ -12,9 +12,9 @@ use energy::{Potential, PairPotential};
 /// # Examples
 ///
 /// ```
-/// # use lumol::energy::Potential;
-/// use lumol::energy::Computation;
-/// use lumol::energy::Harmonic;
+/// # use lumol_core::energy::Potential;
+/// use lumol_core::energy::Computation;
+/// use lumol_core::energy::Harmonic;
 ///
 /// /// This is just a thin wrapper logging every time the `energy/force`
 /// /// methods are called.
@@ -85,9 +85,9 @@ impl TableComputation {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::energy::Potential;
-    /// use lumol::energy::TableComputation;
-    /// use lumol::energy::Harmonic;
+    /// # use lumol_core::energy::Potential;
+    /// use lumol_core::energy::TableComputation;
+    /// use lumol_core::energy::Harmonic;
     ///
     /// let potential = Box::new(Harmonic{x0: 0.5, k: 4.2});
     /// let table = TableComputation::new(potential, 1000, 2.0);

--- a/src/core/src/energy/functions.rs
+++ b/src/core/src/energy/functions.rs
@@ -13,8 +13,8 @@ use energy::{PairPotential, BondPotential, AnglePotential, DihedralPotential};
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::NullPotential;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::NullPotential;
 ///
 /// let potential = NullPotential;
 /// assert_eq!(potential.energy(0.1), 0.0);
@@ -47,8 +47,8 @@ impl DihedralPotential for NullPotential {}
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::LennardJones;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::LennardJones;
 ///
 /// let potential = LennardJones{sigma: 2.0, epsilon: 10.0};
 /// assert_eq!(potential.energy(2.0), 0.0);
@@ -102,8 +102,8 @@ impl PairPotential for LennardJones {
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::Harmonic;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::Harmonic;
 ///
 /// let potential = Harmonic{x0: 2.0, k: 100.0};
 /// assert_eq!(potential.energy(2.0), 0.0);
@@ -152,8 +152,8 @@ impl DihedralPotential for Harmonic {}
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::CosineHarmonic;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::CosineHarmonic;
 ///
 /// let potential = CosineHarmonic::new(/* k */ 100.0, /* x0 */ 2.0);
 /// assert_eq!(potential.energy(2.0), 0.0);
@@ -203,8 +203,8 @@ impl DihedralPotential for CosineHarmonic {}
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::Torsion;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::Torsion;
 /// use std::f64::consts::PI;
 ///
 /// let potential = Torsion{delta: PI / 2.0, k: 10.0, n: 3};
@@ -248,8 +248,8 @@ impl DihedralPotential for Torsion {}
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::Buckingham;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::Buckingham;
 ///
 /// let potential = Buckingham{a: 2.0, c: 1.0, rho: 5.3};
 /// assert_eq!(potential.energy(2.2), 1.3117360696239022);
@@ -309,8 +309,8 @@ impl PairPotential for Buckingham {
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::BornMayerHuggins;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::BornMayerHuggins;
 ///
 /// let potential = BornMayerHuggins{a: 2.0, c: 1.0, d: 0.5, sigma: 1.5, rho: 5.3};
 /// assert_eq!(potential.energy(2.2), 1.7446409593340713);
@@ -373,8 +373,8 @@ impl PairPotential for BornMayerHuggins {
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Potential;
-/// use lumol::energy::MorsePotential;
+/// use lumol_core::energy::Potential;
+/// use lumol_core::energy::MorsePotential;
 ///
 /// let potential = MorsePotential{a: 2.0, x0: 1.3, depth: 4.0};
 /// assert_eq!(potential.energy(1.0), 2.703517287822119);

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -29,17 +29,17 @@ use super::{GlobalPotential, CoulombicPotential, GlobalCache};
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::{Ewald, SharedEwald};
-/// use lumol::units;
+/// use lumol_core::energy::{Ewald, SharedEwald};
+/// use lumol_core::units;
 ///
 /// let ewald = SharedEwald::new(
 ///     Ewald::new(/* cutoff */ 12.0, /* kmax */ 7)
 /// );
 ///
-/// use lumol::sys::System;
-/// use lumol::sys::Particle;
-/// use lumol::sys::UnitCell;
-/// use lumol::types::Vector3D;
+/// use lumol_core::sys::System;
+/// use lumol_core::sys::Particle;
+/// use lumol_core::sys::UnitCell;
+/// use lumol_core::types::Vector3D;
 ///
 /// // Setup a system containing a NaCl pair
 /// let mut system = System::with_cell(UnitCell::cubic(10.0));
@@ -737,7 +737,7 @@ impl SharedEwald {
     ///
     /// # Example
     /// ```
-    /// # use lumol::energy::{Ewald, SharedEwald, CoulombicPotential};
+    /// # use lumol_core::energy::{Ewald, SharedEwald, CoulombicPotential};
     /// let ewald = SharedEwald::new(Ewald::new(12.5, 10));
     /// let boxed: Box<CoulombicPotential> = Box::new(ewald);
     /// ```

--- a/src/core/src/energy/global/mod.rs
+++ b/src/core/src/energy/global/mod.rs
@@ -28,9 +28,9 @@ use energy::PairRestriction;
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::{GlobalPotential, GlobalCache};
-/// use lumol::types::{Vector3D, Matrix3, Zero};
-/// use lumol::sys::{System, Configuration, Particle, UnitCell};
+/// use lumol_core::energy::{GlobalPotential, GlobalCache};
+/// use lumol_core::types::{Vector3D, Matrix3, Zero};
+/// use lumol_core::sys::{System, Configuration, Particle, UnitCell};
 ///
 /// /// Shift the energy of all the particles by a given delta.
 /// #[derive(Clone)]
@@ -118,9 +118,9 @@ impl_box_clone!(GlobalPotential, BoxCloneGlobal, box_clone_gobal);
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::{GlobalPotential, GlobalCache};
-/// use lumol::types::{Vector3D, Matrix3, Zero};
-/// use lumol::sys::{Configuration, Particle};
+/// use lumol_core::energy::{GlobalPotential, GlobalCache};
+/// use lumol_core::types::{Vector3D, Matrix3, Zero};
+/// use lumol_core::sys::{Configuration, Particle};
 ///
 /// /// Shift the energy of all the particles by a given delta.
 /// #[derive(Clone)]

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -21,16 +21,16 @@ use super::{GlobalPotential, CoulombicPotential, GlobalCache};
 /// # Examples
 ///
 /// ```
-/// use lumol::energy::Wolf;
-/// use lumol::units;
+/// use lumol_core::energy::Wolf;
+/// use lumol_core::units;
 ///
 /// // A relatively large cutoff is needed for Wolf summation
 /// let wolf = Wolf::new(12.0);
 ///
-/// use lumol::sys::System;
-/// use lumol::sys::Particle;
-/// use lumol::sys::UnitCell;
-/// use lumol::types::Vector3D;
+/// use lumol_core::sys::System;
+/// use lumol_core::sys::Particle;
+/// use lumol_core::sys::UnitCell;
+/// use lumol_core::types::Vector3D;
 ///
 /// // Setup a system containing a NaCl pair
 /// let mut system = System::with_cell(UnitCell::cubic(10.0));

--- a/src/core/src/energy/mod.rs
+++ b/src/core/src/energy/mod.rs
@@ -23,7 +23,7 @@
 //!   interactions.
 //!
 //! ```
-//! use lumol::energy::{Potential, PairPotential, DihedralPotential};
+//! use lumol_core::energy::{Potential, PairPotential, DihedralPotential};
 //!
 //! #[derive(Clone)]
 //! struct OnePotential;
@@ -72,7 +72,7 @@ use types::{Matrix3, Vector3D};
 ///
 /// ```
 /// # use std::f64;
-/// use lumol::energy::Potential;
+/// use lumol_core::energy::Potential;
 ///
 /// /// An hard sphere potential
 /// #[derive(Clone)]
@@ -108,8 +108,8 @@ pub trait Potential : Sync + Send {
 /// # Example
 ///
 /// ```
-/// # use lumol::types::{Zero, Matrix3};
-/// use lumol::energy::{Potential, PairPotential};
+/// # use lumol_core::types::{Zero, Matrix3};
+/// use lumol_core::energy::{Potential, PairPotential};
 ///
 /// // A no-op potential
 /// #[derive(Clone)]
@@ -169,7 +169,7 @@ impl_box_clone!(PairPotential, BoxClonePair, box_clone_pair);
 /// # Example
 ///
 /// ```
-/// use lumol::energy::{Potential, BondPotential};
+/// use lumol_core::energy::{Potential, BondPotential};
 ///
 /// // A no-op potential
 /// #[derive(Clone)]
@@ -200,7 +200,7 @@ impl_box_clone!(BondPotential, BoxCloneBond, box_clone_bond);
 /// # Example
 ///
 /// ```
-/// use lumol::energy::{Potential, AnglePotential};
+/// use lumol_core::energy::{Potential, AnglePotential};
 ///
 /// // A no-op potential
 /// #[derive(Clone)]
@@ -222,7 +222,7 @@ impl_box_clone!(AnglePotential, BoxCloneAngle, box_clone_angle);
 /// # Example
 ///
 /// ```
-/// use lumol::energy::{Potential, DihedralPotential};
+/// use lumol_core::energy::{Potential, DihedralPotential};
 ///
 /// // A no-op potential
 /// #[derive(Clone)]

--- a/src/core/src/energy/pairs.rs
+++ b/src/core/src/energy/pairs.rs
@@ -44,8 +44,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::Harmonic;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::Harmonic;
     ///
     /// let potential = Box::new(Harmonic{x0: 0.5, k: 4.2});
     /// let interaction = PairInteraction::new(potential, 2.0);
@@ -70,8 +70,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::Harmonic;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::Harmonic;
     ///
     /// let potential = Box::new(Harmonic{x0: 0.5, k: 4.2});
     /// let interaction = PairInteraction::shifted(potential, 2.0);
@@ -100,8 +100,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::LennardJones;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::LennardJones;
     ///
     /// let potential = Box::new(LennardJones{sigma: 0.5, epsilon: 4.2});
     /// let mut interaction = PairInteraction::new(potential, 2.0);
@@ -121,8 +121,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::{NullPotential, PairRestriction};
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::{NullPotential, PairRestriction};
     /// let interaction = PairInteraction::new(Box::new(NullPotential), 2.0);
     ///
     /// assert_eq!(interaction.restriction(), PairRestriction::None);
@@ -136,8 +136,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::{NullPotential, PairRestriction};
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::{NullPotential, PairRestriction};
     /// let mut interaction = PairInteraction::new(Box::new(NullPotential), 2.0);
     ///
     /// assert_eq!(interaction.restriction(), PairRestriction::None);
@@ -153,8 +153,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::LennardJones;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::LennardJones;
     ///
     /// let ar = LennardJones{sigma: 3.405, epsilon: 1.0};
     /// let interaction = PairInteraction::new(Box::new(ar), 9.1935);
@@ -172,8 +172,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::Harmonic;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::Harmonic;
     ///
     /// let potential = Box::new(Harmonic{x0: 0.5, k: 4.2});
     /// let interaction = PairInteraction::new(potential, 2.0);
@@ -199,8 +199,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::Harmonic;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::Harmonic;
     ///
     /// let potential = Box::new(Harmonic{x0: 0.5, k: 4.2});
     /// let interaction = PairInteraction::new(potential, 2.0);
@@ -223,9 +223,9 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::Harmonic;
-    /// # use lumol::types::Vector3D;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::Harmonic;
+    /// # use lumol_core::types::Vector3D;
     ///
     /// let potential = Box::new(Harmonic{x0: 0.5, k: 4.2});
     /// let interaction = PairInteraction::shifted(potential, 2.0);
@@ -247,8 +247,8 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::LennardJones;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::LennardJones;
     ///
     /// let potential = Box::new(LennardJones{sigma: 0.5, epsilon: 4.2});
     /// let mut interaction = PairInteraction::new(potential, 2.0);
@@ -269,9 +269,9 @@ impl PairInteraction {
     /// # Examples
     ///
     /// ```
-    /// use lumol::energy::PairInteraction;
-    /// use lumol::energy::LennardJones;
-    /// # use lumol::types::Matrix3;
+    /// use lumol_core::energy::PairInteraction;
+    /// use lumol_core::energy::LennardJones;
+    /// # use lumol_core::types::Matrix3;
     ///
     /// let potential = Box::new(LennardJones{sigma: 0.5, epsilon: 4.2});
     /// let mut interaction = PairInteraction::new(potential, 2.0);

--- a/src/core/src/energy/restrictions.rs
+++ b/src/core/src/energy/restrictions.rs
@@ -50,7 +50,7 @@ impl PairRestriction {
     /// # Example
     ///
     /// ```
-    /// # use lumol::energy::PairRestriction;
+    /// # use lumol_core::energy::PairRestriction;
     /// let restriction = PairRestriction::None;
     /// assert_eq!(restriction.information(3).excluded, false);
     /// assert_eq!(restriction.information(2).scaling, 1.0);

--- a/src/core/src/parallel/shortcuts.rs
+++ b/src/core/src/parallel/shortcuts.rs
@@ -14,7 +14,7 @@ use ndarray::Zip;
 /// # Example
 ///
 /// ```
-/// use lumol::parallel::prelude::*;
+/// use lumol_core::parallel::prelude::*;
 ///
 /// let s = (0..100_i32).par_map(|i| -i).sum();
 /// assert_eq!(-4950, s);

--- a/src/core/src/parallel/thread_local_store.rs
+++ b/src/core/src/parallel/thread_local_store.rs
@@ -23,8 +23,8 @@ use thread_local::CachedThreadLocal;
 ///
 /// ```
 ///
-/// use lumol::parallel::prelude::*;
-/// use lumol::parallel::ThreadLocalStore;
+/// use lumol_core::parallel::prelude::*;
+/// use lumol_core::parallel::ThreadLocalStore;
 ///
 /// let store = ThreadLocalStore::new(|| vec![0, 0, 0]);
 ///

--- a/src/core/src/sim/utils.rs
+++ b/src/core/src/sim/utils.rs
@@ -9,7 +9,7 @@
 /// # Example
 ///
 /// ```
-/// use lumol::sim::Alternator;
+/// use lumol_core::sim::Alternator;
 ///
 /// struct HelloWorld;
 ///

--- a/src/core/src/sys/chfl.rs
+++ b/src/core/src/sys/chfl.rs
@@ -226,7 +226,7 @@ impl ToChemfiles for System {
 /// # Examples
 ///
 /// ```no_run
-/// # use lumol::sys::TrajectoryBuilder;
+/// # use lumol_core::sys::TrajectoryBuilder;
 /// let mut trajectory = TrajectoryBuilder::new()
 ///                                       .open("file.xyz")
 ///                                       .unwrap();
@@ -254,7 +254,7 @@ pub enum OpenMode {
 /// # Examples
 ///
 /// ```no_run
-/// # use lumol::sys::{TrajectoryBuilder, OpenMode};
+/// # use lumol_core::sys::{TrajectoryBuilder, OpenMode};
 /// let trajectory = TrajectoryBuilder::new()
 ///                                    .mode(OpenMode::Read)
 ///                                    .open("file.xyz")
@@ -271,7 +271,7 @@ impl<'a> TrajectoryBuilder<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::{TrajectoryBuilder, OpenMode};
+    /// # use lumol_core::sys::{TrajectoryBuilder, OpenMode};
     /// let trajectory = TrajectoryBuilder::new()
     ///                                    .open("file.xyz")
     ///                                    .unwrap();
@@ -291,7 +291,7 @@ impl<'a> TrajectoryBuilder<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::TrajectoryBuilder;
+    /// # use lumol_core::sys::TrajectoryBuilder;
     /// let trajectory = TrajectoryBuilder::new()
     ///                                    .format("PDB")
     ///                                    .open("file.mol")
@@ -309,7 +309,7 @@ impl<'a> TrajectoryBuilder<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::{TrajectoryBuilder, OpenMode};
+    /// # use lumol_core::sys::{TrajectoryBuilder, OpenMode};
     /// let trajectory = TrajectoryBuilder::new()
     ///                                    .mode(OpenMode::Write)
     ///                                    .open("file.nc")
@@ -327,7 +327,7 @@ impl<'a> TrajectoryBuilder<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::TrajectoryBuilder;
+    /// # use lumol_core::sys::TrajectoryBuilder;
     /// let trajectory = TrajectoryBuilder::new()
     ///                                    .open("file.nc")
     ///                                    .unwrap();
@@ -351,7 +351,7 @@ impl Trajectory {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::TrajectoryBuilder;
+    /// # use lumol_core::sys::TrajectoryBuilder;
     /// let mut trajectory = TrajectoryBuilder::new()
     ///                                       .open("file.nc")
     ///                                       .unwrap();
@@ -370,7 +370,7 @@ impl Trajectory {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::TrajectoryBuilder;
+    /// # use lumol_core::sys::TrajectoryBuilder;
     /// let mut trajectory = TrajectoryBuilder::new()
     ///                                       .open("file.nc")
     ///                                       .unwrap();
@@ -389,7 +389,7 @@ impl Trajectory {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::{System, TrajectoryBuilder, OpenMode};
+    /// # use lumol_core::sys::{System, TrajectoryBuilder, OpenMode};
     /// # let system = System::new();
     /// let mut trajectory = TrajectoryBuilder::new()
     ///                                       .mode(OpenMode::Write)
@@ -411,7 +411,7 @@ impl Trajectory {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::{TrajectoryBuilder, UnitCell};
+    /// # use lumol_core::sys::{TrajectoryBuilder, UnitCell};
     /// let mut trajectory = TrajectoryBuilder::new()
     ///                                       .open("file.xyz")
     ///                                       .unwrap();
@@ -435,7 +435,7 @@ impl Trajectory {
     /// # Examples
     ///
     /// ```no_run
-    /// # use lumol::sys::TrajectoryBuilder;
+    /// # use lumol_core::sys::TrajectoryBuilder;
     /// let mut trajectory = TrajectoryBuilder::new()
     ///                                       .open("file.xyz")
     ///                                       .unwrap();
@@ -456,7 +456,7 @@ impl Trajectory {
 /// # Examples
 ///
 /// ```no_run
-/// # use lumol::sys::read_molecule;
+/// # use lumol_core::sys::read_molecule;
 /// let (molecule, particles) = read_molecule("file.xyz").unwrap();
 /// assert_eq!(molecule.size(), particles.len());
 /// ```

--- a/src/core/src/sys/config/composition.rs
+++ b/src/core/src/sys/config/composition.rs
@@ -9,7 +9,7 @@ use sys::ParticleKind;
 ///
 /// # Examples
 /// ```
-/// # use lumol::sys::{Composition, ParticleKind};
+/// # use lumol_core::sys::{Composition, ParticleKind};
 /// let mut composition = Composition::new();
 /// composition.resize(10);
 ///
@@ -29,7 +29,7 @@ impl Composition {
     ///
     /// # Examples
     /// ```
-    /// # use lumol::sys::Composition;
+    /// # use lumol_core::sys::Composition;
     /// let composition = Composition::new();
     /// assert_eq!(composition.len(), 0);
     /// ```
@@ -42,7 +42,7 @@ impl Composition {
     ///
     /// # Examples
     /// ```
-    /// # use lumol::sys::Composition;
+    /// # use lumol_core::sys::Composition;
     /// let mut composition = Composition::new();
     /// assert_eq!(composition.len(), 0);
     ///
@@ -59,7 +59,7 @@ impl Composition {
     ///
     /// # Examples
     /// ```
-    /// # use lumol::sys::Composition;
+    /// # use lumol_core::sys::Composition;
     /// let mut composition = Composition::new();
     /// assert_eq!(composition.len(), 0);
     /// assert!(composition.is_empty());
@@ -73,7 +73,7 @@ impl Composition {
     ///
     /// # Examples
     /// ```
-    /// # use lumol::sys::{Composition, ParticleKind};
+    /// # use lumol_core::sys::{Composition, ParticleKind};
     /// let mut composition = Composition::new();
     /// assert_eq!(composition.len(), 0);
     ///

--- a/src/core/src/types/arrays.rs
+++ b/src/core/src/types/arrays.rs
@@ -14,7 +14,7 @@ use types::Zero;
 /// indices and is though as storage backend for multi-dimensional data.
 ///
 /// ```
-/// # use lumol::types::Array2;
+/// # use lumol_core::types::Array2;
 /// let mut a = Array2::zeros((3, 5));
 ///
 /// assert_eq!(a[(0, 4)], 0.0);
@@ -32,7 +32,7 @@ impl<T: Zero + Clone> Array2<T> {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Array2;
+    /// # use lumol_core::types::Array2;
     /// let a: Array2<f64> = Array2::zeros((8, 5));
     /// assert_eq!(a[(6, 2)], 0.0);
     /// ```
@@ -46,7 +46,7 @@ impl<T: Zero + Clone> Array2<T> {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Array2;
+    /// # use lumol_core::types::Array2;
     /// let mut a = Array2::zeros((8, 5));
     ///
     /// a[(3, 3)] = 42.0;
@@ -73,7 +73,7 @@ impl<T: Default> Array2<T> {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Array2;
+    /// # use lumol_core::types::Array2;
     /// let a: Array2<f64> = Array2::zeros((8, 5));
     /// let b: Array2<f64> = Array2::default((8, 5));
     ///
@@ -126,7 +126,7 @@ impl<T> DerefMut for Array2<T> {
 /// indices and is though as storage backend for multi-dimensional data.
 ///
 /// ```
-/// # use lumol::types::Array3;
+/// # use lumol_core::types::Array3;
 /// let mut a = Array3::zeros((3, 5, 2));
 ///
 /// assert_eq!(a[(0, 4, 1)], 0.0);
@@ -144,7 +144,7 @@ impl<T> Array3<T> {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Array3;
+    /// # use lumol_core::types::Array3;
     /// let a: Array3<f64> = Array3::zeros((8, 5, 2));
     /// assert_eq!(a[(6, 2, 0)], 0.0);
     /// ```
@@ -158,7 +158,7 @@ impl<T> Array3<T> {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Array3;
+    /// # use lumol_core::types::Array3;
     /// let mut a = Array3::zeros((8, 5, 7));
     ///
     /// a[(3, 3, 3)] = 42.0;
@@ -184,7 +184,7 @@ impl<T> Array3<T> {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Array3;
+    /// # use lumol_core::types::Array3;
     /// let a: Array3<f64> = Array3::zeros((8, 5, 2));
     /// let b: Array3<f64> = Array3::default((8, 5, 2));
     ///

--- a/src/core/src/types/complex.rs
+++ b/src/core/src/types/complex.rs
@@ -13,7 +13,7 @@ use types::{Zero, One};
 /// `Complex` implements all the usual arithmetic operations:
 ///
 /// ```
-/// # use lumol::types::Complex;
+/// # use lumol_core::types::Complex;
 ///
 /// let w = Complex::cartesian(-1.0, 0.5);
 /// let z = Complex::cartesian(4.0, 2.0);
@@ -48,7 +48,7 @@ impl Complex {
     /// Create a new `Complex` from a norm `r` and a phase `phi` in radians.
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// # use std::f64;
     /// let z = Complex::polar(3.0, f64::consts::PI);
     /// assert_eq!(z.norm(), 3.0);
@@ -63,7 +63,7 @@ impl Complex {
     /// Create a complex from Cartesian coordinates
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// let z = Complex::cartesian(3.0, -2.0);
     /// assert_eq!(z.real(), 3.0);
     /// assert_eq!(z.imag(), -2.0);
@@ -78,7 +78,7 @@ impl Complex {
     /// Get the real part of the complex
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// let z = Complex::cartesian(3.0, -2.0);
     /// assert_eq!(z.real(), 3.0);
     /// ```
@@ -90,7 +90,7 @@ impl Complex {
     /// Get the imaginary part of the complex
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// let z = Complex::cartesian(3.0, -2.0);
     /// assert_eq!(z.imag(), -2.0);
     /// ```
@@ -102,7 +102,7 @@ impl Complex {
     /// Get the phase of the complex in the [-π, π) interval
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// let z = Complex::polar(2.0, 0.3);
     /// assert_eq!(z.phase(), 0.3);
     /// ```
@@ -114,7 +114,7 @@ impl Complex {
     /// Get the norm of the complex
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// # use std::f64;
     /// let z = Complex::polar(2.0, 0.3);
     /// assert_eq!(z.norm(), 2.0);
@@ -130,7 +130,7 @@ impl Complex {
     /// Get the square of the norm if this complex
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// let z = Complex::cartesian(2.0, 1.0);
     /// assert_eq!(z.norm2(), 5.0);
     /// ```
@@ -142,7 +142,7 @@ impl Complex {
     /// Get the conjugate of the complex
     /// # Examples
     /// ```
-    /// # use lumol::types::Complex;
+    /// # use lumol_core::types::Complex;
     /// let z = Complex::cartesian(2.0, 1.0);
     /// assert_eq!(z.conj(), Complex::cartesian(2.0, -1.0));
     /// ```

--- a/src/core/src/types/matrix.rs
+++ b/src/core/src/types/matrix.rs
@@ -13,7 +13,7 @@ use types::{Vector3D, Zero, One};
 /// `Matrix3` implements all the usual arithmetic operations:
 ///
 /// ```
-/// use lumol::types::{Matrix3, Vector3D, One};
+/// use lumol_core::types::{Matrix3, Vector3D, One};
 ///
 /// let one = Matrix3::one();
 /// let a = Matrix3::new(
@@ -75,7 +75,7 @@ impl Matrix3 {
     /// Create a new `Matrix3` specifying all its components
     /// # Examples
     /// ```
-    /// # use lumol::types::Matrix3;
+    /// # use lumol_core::types::Matrix3;
     /// let matrix = Matrix3::new(
     ///     0.0, 0.0, 3.0,
     ///     0.0, 1.0, 5.6,
@@ -98,7 +98,7 @@ impl Matrix3 {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::{Vector3D, Matrix3};
+    /// # use lumol_core::types::{Vector3D, Matrix3};
     /// let e1 = Vector3D::new(1.0f64, 0.0, 0.0);
     /// let e3 = Vector3D::new(0.0f64, 0.0, 1.0);
     /// let angle = 90f64.to_radians();
@@ -140,7 +140,7 @@ impl Matrix3 {
     /// Compute the trace of the matrix
     /// # Examples
     /// ```
-    /// # use lumol::types::Matrix3;
+    /// # use lumol_core::types::Matrix3;
     /// let matrix = Matrix3::new(
     ///     0.0, 0.0, 3.0,
     ///     0.0, 1.0, 5.6,
@@ -157,7 +157,7 @@ impl Matrix3 {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::{Matrix3, One};
+    /// # use lumol_core::types::{Matrix3, One};
     /// // A diagonal matrix is trivially invertible
     /// let matrix = Matrix3::new(
     ///     4.0, 0.0, 0.0,
@@ -203,7 +203,7 @@ impl Matrix3 {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Matrix3;
+    /// # use lumol_core::types::Matrix3;
     /// let matrix = Matrix3::new(
     ///     4.0, 0.0, 0.0,
     ///     0.0, 1.5, 0.0,
@@ -222,7 +222,7 @@ impl Matrix3 {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Matrix3;
+    /// # use lumol_core::types::Matrix3;
     /// let matrix = Matrix3::new(
     ///     1.0, 2.0, 4.0,
     ///     0.0, 1.0, 3.0,

--- a/src/core/src/types/vectors.rs
+++ b/src/core/src/types/vectors.rs
@@ -13,7 +13,7 @@ use types::{Matrix3, Zero};
 /// A `Vector3D` implement all the arithmetic operations:
 ///
 /// ```
-/// # use lumol::types::Vector3D;
+/// # use lumol_core::types::Vector3D;
 /// let u = Vector3D::new(1.0, 2.0, 3.0);
 /// let v = Vector3D::new(4.0, -2.0, 1.0);
 ///
@@ -61,7 +61,7 @@ impl Vector3D {
     ///
     /// # Examples
     /// ```
-    /// # use lumol::types::Vector3D;
+    /// # use lumol_core::types::Vector3D;
     /// let vec = Vector3D::new(1.0, 0.0, -42.0);
     /// ```
     pub fn new(x: f64, y: f64, z: f64) -> Vector3D {
@@ -72,7 +72,7 @@ impl Vector3D {
     ///
     /// # Examples
     /// ```
-    /// # use lumol::types::Vector3D;
+    /// # use lumol_core::types::Vector3D;
     /// let vec = Vector3D::new(1.0, 0.0, -4.0);
     /// assert_eq!(vec.norm2(), 17.0);
     /// ```
@@ -83,7 +83,7 @@ impl Vector3D {
     /// Return the euclidean norm of a `Vector3D`
     /// # Examples
     /// ```
-    /// # use lumol::types::Vector3D;
+    /// # use lumol_core::types::Vector3D;
     /// # use std::f64;
     /// let vec = Vector3D::new(1.0, 0.0, -4.0);
     /// assert_eq!(vec.norm(), f64::sqrt(17.0));
@@ -95,7 +95,7 @@ impl Vector3D {
     /// Normalize a `Vector3D`.
     /// # Examples
     /// ```
-    /// # use lumol::types::Vector3D;
+    /// # use lumol_core::types::Vector3D;
     /// let vec = Vector3D::new(1.0, 0.0, -4.0);
     /// let n = vec.normalized();
     /// assert_eq!(n.norm(), 1.0);
@@ -111,8 +111,8 @@ impl Vector3D {
     /// # Examples
     ///
     /// ```
-    /// # use lumol::types::Vector3D;
-    /// # use lumol::types::Matrix3;
+    /// # use lumol_core::types::Vector3D;
+    /// # use lumol_core::types::Matrix3;
     /// let a = Vector3D::new(1.0, 0.0, -4.0);
     /// let b = Vector3D::new(1.0, 2.0, 3.0);
     /// let matrix = Matrix3::new(

--- a/src/core/src/units.rs
+++ b/src/core/src/units.rs
@@ -367,7 +367,7 @@ fn read_expr(stream: &mut Vec<Token>) -> Result<UnitExpr, ParseError> {
 /// Convert the numeric value `val` from the unit `unit` to the internal unit.
 ///
 /// ```
-/// use lumol::units;
+/// use lumol_core::units;
 /// let internal = units::from(10.0, "A").unwrap();
 /// assert!(internal == 10.0);
 /// ```
@@ -379,7 +379,7 @@ pub fn from(value: f64, unit: &str) -> Result<f64, ParseError> {
 /// Parse the string `val` and convert it to the corresponding internal unit
 ///
 /// ```
-/// use lumol::units;
+/// use lumol_core::units;
 /// let internal = units::from_str("10 A").unwrap();
 /// assert!(internal == 10.0);
 /// ```
@@ -398,7 +398,7 @@ pub fn from_str(value: &str) -> Result<f64, ParseError> {
 /// Convert the numeric value `val` (in internal units) to the unit `unit`.
 ///
 /// ```
-/// use lumol::units;
+/// use lumol_core::units;
 /// let real = units::to(10.0, "A").unwrap();
 /// assert!(real == 10.0);
 /// ```

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -28,9 +28,9 @@
 //! from a TOML file. It can be used to set the interactions in a system:
 //!
 //! ```no_run
-//! extern crate lumol;
+//! extern crate lumol_core;
 //! extern crate lumol_input;
-//! use lumol::sys::System;
+//! use lumol_core::sys::System;
 //! use lumol_input::InteractionsInput;
 //!
 //! fn main() {
@@ -61,7 +61,7 @@
     unseparated_literal_suffix, new_without_default_derive, use_self
 )]
 
-extern crate lumol;
+extern crate lumol_core as lumol;
 extern crate toml;
 extern crate chemfiles;
 

--- a/src/input/tests/input.rs
+++ b/src/input/tests/input.rs
@@ -4,7 +4,7 @@ extern crate test;
 extern crate walkdir;
 extern crate env_logger;
 
-extern crate lumol;
+extern crate lumol_core;
 extern crate lumol_input;
 
 use std::{env, fs, io};
@@ -17,7 +17,7 @@ use walkdir::WalkDir;
 use test::{TestDesc, TestDescAndFn, DynTestName, DynTestFn};
 use test::ShouldPanic::No;
 
-use lumol::sys::System;
+use lumol_core::sys::System;
 use lumol_input::{InteractionsInput, Input, Error};
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+extern crate lumol_core;
+
+pub use lumol_core::*;


### PR DESCRIPTION
It makes things confusing for external users how need to declare a dependency on lumol-core, but get to use extern crate lumol. Instead, add an actual lumol crate, re-exporting everything from lumol-core.

This allow to use the 'lumol' name both in dependencies and in extern crate.
