### PR TITLE
Remove global translation and rotation on velocities initialization

### DIFF
--- a/src/core/src/sim/md/controls.rs
+++ b/src/core/src/sim/md/controls.rs
@@ -109,7 +109,6 @@ impl Thermostat for BerendsenThermostat {}
 /******************************************************************************/
 
 impl<T> Control for Alternator<T> where T: Control {
-
     fn control(&mut self, system: &mut System) {
         if self.can_run() {
             self.as_mut().control(system)


### PR DESCRIPTION
This prevent the flying ice-cube effect when the random velocity is not 100% isotropic