### PR TITLE
Cleanup of math heavy code

### DIFF
--- a/src/core/src/energy/computations.rs
+++ b/src/core/src/energy/computations.rs
@@ -1,6 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
 
+use math::*;
 use energy::{Potential, PairPotential};
 
 /// Alternative energy and forces computation.
@@ -118,7 +119,7 @@ impl TableComputation {
 impl Computation for TableComputation {
     fn compute_energy(&self, r: f64) -> f64 {
         debug_assert_eq!(self.energy_table.len(), self.force_table.len());
-        let bin = f64::floor(r / self.delta) as usize;
+        let bin = floor(r / self.delta) as usize;
         if bin < self.energy_table.len() - 1 {
             let dx = r - (bin as f64) * self.delta;
             let slope = (self.energy_table[bin + 1] - self.energy_table[bin]) / self.delta;
@@ -130,7 +131,7 @@ impl Computation for TableComputation {
 
     fn compute_force(&self, r: f64) -> f64 {
         debug_assert_eq!(self.energy_table.len(), self.force_table.len());
-        let bin = f64::floor(r / self.delta) as usize;
+        let bin = floor(r / self.delta) as usize;
         if bin < self.force_table.len() - 1 {
             let dx = r - (bin as f64) * self.delta;
             let slope = (self.force_table[bin + 1] - self.force_table[bin]) / self.delta;

--- a/src/core/src/energy/functions.rs
+++ b/src/core/src/energy/functions.rs
@@ -1,6 +1,7 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
 
+use math::*;
 use energy::Potential;
 use energy::{PairPotential, BondPotential, AnglePotential, DihedralPotential};
 
@@ -173,18 +174,18 @@ impl CosineHarmonic {
     /// Create a new `CosineHarmonic` potentials, with elastic constant of `k`
     /// and equilibrium value of `x0`
     pub fn new(k: f64, x0:f64) -> CosineHarmonic {
-        CosineHarmonic{k: k, cos_x0: f64::cos(x0)}
+        CosineHarmonic{k: k, cos_x0: cos(x0)}
     }
 }
 
 impl Potential for CosineHarmonic {
     fn energy(&self, x: f64) -> f64 {
-        let dr = f64::cos(x) - self.cos_x0;
+        let dr = cos(x) - self.cos_x0;
         0.5 * self.k * dr * dr
     }
 
     fn force(&self, x: f64) -> f64 {
-        self.k * (f64::cos(x) - self.cos_x0) * f64::sin(x)
+        self.k * (cos(x) - self.cos_x0) * sin(x)
     }
 }
 
@@ -226,13 +227,13 @@ pub struct Torsion {
 impl Potential for Torsion {
     fn energy(&self, phi: f64) -> f64 {
         let n = self.n as f64;
-        let cos = f64::cos(n * phi - self.delta);
+        let cos = cos(n * phi - self.delta);
         self.k * (1.0 + cos)
     }
 
     fn force(&self, phi: f64) -> f64 {
         let n = self.n as f64;
-        let sin = f64::sin(n * phi - self.delta);
+        let sin = sin(n * phi - self.delta);
         self.k * n * sin
     }
 }
@@ -269,14 +270,14 @@ impl Potential for Buckingham {
     fn energy(&self, r: f64) -> f64 {
         let r3 = r * r * r;
         let r6 = r3 * r3;
-        let exp = f64::exp(- r / self.rho);
+        let exp = exp(- r / self.rho);
         self.a * exp - self.c / r6
     }
 
     fn force(&self, r: f64) -> f64 {
         let r3 = r * r * r;
         let r7 = r3 * r3 * r;
-        let exp = f64::exp(- r / self.rho);
+        let exp = exp(- r / self.rho);
         self.a / self.rho * exp - 6.0 * self.c / r7
     }
 }
@@ -285,7 +286,7 @@ impl PairPotential for Buckingham {
     fn tail_energy(&self, rc: f64) -> f64 {
         let rc2 = rc * rc;
         let rc3 = rc2 * rc;
-        let exp = f64::exp(- rc / self.rho);
+        let exp = exp(- rc / self.rho);
         let factor = rc2 - 2.0 * rc * self.rho + 2.0 * self.rho * self.rho;
         self.a * self.rho * exp * factor - self.c / (3.0 * rc3)
     }
@@ -293,7 +294,7 @@ impl PairPotential for Buckingham {
     fn tail_virial(&self, rc: f64) -> f64 {
         let rc2 = rc * rc;
         let rc3 = rc2 * rc;
-        let exp = f64::exp(- rc / self.rho);
+        let exp = exp(- rc / self.rho);
         let factor = rc3 + 3.0 * rc2 * self.rho + 6.0 * rc * self.rho * self.rho + 6.0 * self.rho * self.rho * self.rho;
         self.a * exp * factor - 20.0 * self.c / rc3 + 8.0
     }
@@ -334,14 +335,14 @@ impl Potential for BornMayerHuggins {
     fn energy(&self, r: f64) -> f64 {
         let r2 = r * r;
         let r6 = r2 * r2 * r2;
-        let exp = f64::exp((self.sigma - r) / self.rho);
+        let exp = exp((self.sigma - r) / self.rho);
         self.a * exp - self.c / r6 + self.d / (r6 * r2)
     }
 
     fn force(&self, r: f64) -> f64 {
         let r2 = r * r;
         let r7 = r2 * r2 * r2 * r;
-        let exp = f64::exp((self.sigma - r) / self.rho);
+        let exp = exp((self.sigma - r) / self.rho);
         self.a / self.rho * exp - 6.0 * self.c / r7 + 8.0 * self.d / (r7 * r2)
     }
 }
@@ -350,7 +351,7 @@ impl PairPotential for BornMayerHuggins {
     fn tail_energy(&self, rc: f64) -> f64 {
         let rc2 = rc * rc;
         let rc3 = rc2 * rc;
-        let exp = f64::exp((self.sigma - rc) / self.rho);
+        let exp = exp((self.sigma - rc) / self.rho);
         let factor = rc2 - 2.0 * rc * self.rho + 2.0 * self.rho * self.rho;
         self.a * self.rho * exp * factor - self.c / (3.0 * rc3) + self.d / (5.0 * rc2 * rc3)
     }
@@ -358,7 +359,7 @@ impl PairPotential for BornMayerHuggins {
     fn tail_virial(&self, rc: f64) -> f64 {
         let rc2 = rc * rc;
         let rc3 = rc2 * rc;
-        let exp = f64::exp((self.sigma - rc) / self.rho);
+        let exp = exp((self.sigma - rc) / self.rho);
         let factor = rc3 + 3.0 * rc2 * self.rho + 6.0 * rc * self.rho * self.rho + 6.0 * self.rho * self.rho * self.rho;
         self.a * exp * factor - 20.0 * self.c / rc3 + 8.0 * self.d / (5.0 * rc2 * rc3)
     }
@@ -392,12 +393,12 @@ pub struct MorsePotential {
 
 impl Potential for MorsePotential {
     fn energy(&self, r: f64) -> f64 {
-        let rc = 1.0 - f64::exp((self.x0 - r) * self.a);
+        let rc = 1.0 - exp((self.x0 - r) * self.a);
         self.depth * rc * rc
     }
 
     fn force(&self, r: f64) -> f64 {
-        let exp = f64::exp((self.x0 - r) * self.a);
+        let exp = exp((self.x0 - r) * self.a);
         2.0 * self.depth * (1.0 - exp * exp) * self.a
     }
 }
@@ -477,12 +478,12 @@ mod tests {
     fn cosine_harmonic() {
         let harmonic = CosineHarmonic::new(50.0, 2.0);
         assert_eq!(harmonic.energy(2.0), 0.0);
-        let dcos = f64::cos(2.5) - f64::cos(2.0);
+        let dcos = cos(2.5) - cos(2.0);
         assert_eq!(harmonic.energy(2.5), 0.5 * 50.0 * dcos * dcos);
 
         assert_eq!(harmonic.force(2.0), 0.0);
-        let dcos = f64::cos(2.5) - f64::cos(2.0);
-        assert_eq!(harmonic.force(2.5), 50.0 * dcos * f64::sin(2.5));
+        let dcos = cos(2.5) - cos(2.0);
+        assert_eq!(harmonic.force(2.5), 50.0 * dcos * sin(2.5));
 
         let e0 = harmonic.energy(2.3);
         let e1 = harmonic.energy(2.3 + EPS);
@@ -493,7 +494,7 @@ mod tests {
     fn torsion() {
         let torsion = Torsion{k: 5.0, n: 3, delta: 3.0};
         assert_eq!(torsion.energy(1.0), 10.0);
-        let energy = 5.0 * (1.0 + f64::cos(3.0 * 1.1 - 3.0));
+        let energy = 5.0 * (1.0 + cos(3.0 * 1.1 - 3.0));
         assert_eq!(torsion.energy(1.1), energy);
 
         assert_eq!(torsion.force(1.0), 0.0);

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -1,9 +1,8 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
-
-use special::Error;
 use std::f64::consts::PI;
 
+use math::*;
 use sys::Configuration;
 use types::{Matrix3, Vector3D, Zero};
 use consts::ELCC;
@@ -72,9 +71,9 @@ impl Wolf {
     pub fn new(cutoff: f64) -> Wolf {
         assert!(cutoff > 0.0, "Got a negative cutoff in Wolf summation");
         let alpha = PI / cutoff;
-        let e_cst = f64::erfc(alpha * cutoff) / cutoff;
-        let f_cst = f64::erfc(alpha * cutoff) / (cutoff * cutoff)
-                    + 2.0 * alpha / f64::sqrt(PI) * f64::exp(-alpha * alpha * cutoff * cutoff) / cutoff;
+        let e_cst = erfc(alpha * cutoff) / cutoff;
+        let f_cst = erfc(alpha * cutoff) / (cutoff * cutoff)
+                    + 2.0 * alpha / sqrt(PI) * exp(-alpha * alpha * cutoff * cutoff) / cutoff;
         Wolf{
             alpha: alpha,
             cutoff: cutoff,
@@ -92,13 +91,13 @@ impl Wolf {
         if rij > self.cutoff || info.excluded {
             return 0.0;
         }
-        info.scaling * qiqj * (f64::erfc(self.alpha * rij) / rij - self.energy_cst) / ELCC
+        info.scaling * qiqj * (erfc(self.alpha * rij) / rij - self.energy_cst) / ELCC
     }
 
     /// Compute the energy for self interaction of a particle with charge `qi`
     #[inline]
     fn energy_self(&self, qi: f64) -> f64 {
-        qi * qi * (self.energy_cst / 2.0 + self.alpha / f64::sqrt(PI)) / ELCC
+        qi * qi * (self.energy_cst / 2.0 + self.alpha / sqrt(PI)) / ELCC
     }
 
     /// Compute the force for self the pair of particles with charge `qi` and
@@ -110,8 +109,8 @@ impl Wolf {
         if d > self.cutoff || info.excluded {
             return Vector3D::zero();
         }
-        let factor = f64::erfc(self.alpha * d) / (d * d) +
-                     2.0 * self.alpha / f64::sqrt(PI) * f64::exp(-self.alpha * self.alpha * d * d) / d;
+        let factor = erfc(self.alpha * d) / (d * d) +
+                     2.0 * self.alpha / sqrt(PI) * exp(-self.alpha * self.alpha * d * d) / d;
         return info.scaling * qiqj * (factor - self.force_cst) * rij.normalized() / ELCC;
     }
 }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -81,6 +81,7 @@ macro_rules! internal_error {
 // Helper modules
 #[macro_use]
 mod utils;
+mod math;
 
 // Main modules
 pub mod units;

--- a/src/core/src/math.rs
+++ b/src/core/src/math.rs
@@ -1,0 +1,27 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
+
+//! Access usual math function directly, without having to use a `f64::` prefix,
+//! or to resort to method style call.
+
+use special::Error;
+
+macro_rules! make_math_fn {
+    ($name: ident) => (
+        #[inline(always)]
+        pub fn $name(value: f64) -> f64 {
+            f64::$name(value)
+        }
+    );
+}
+
+make_math_fn!(sqrt);
+make_math_fn!(exp);
+make_math_fn!(erf);
+make_math_fn!(erfc);
+make_math_fn!(abs);
+make_math_fn!(cos);
+make_math_fn!(sin);
+make_math_fn!(acos);
+make_math_fn!(floor);
+make_math_fn!(round);

--- a/src/core/src/sys/config/cells.rs
+++ b/src/core/src/sys/config/cells.rs
@@ -6,6 +6,7 @@
 //! a simulated system, with some type of periodic condition.
 use std::f64::consts::PI;
 
+use math::*;
 use types::{Matrix3, Vector3D, Zero};
 
 /// The shape of a cell determine how we will be able to compute the periodic
@@ -83,7 +84,7 @@ impl UnitCell {
 
         let c_x = c * cos_beta;
         let c_y = c * (cos_alpha - cos_beta * cos_gamma) / sin_gamma;
-        let c_z = f64::sqrt(c * c - c_y * c_y - c_x * c_x);
+        let c_z = sqrt(c * c - c_y * c_y - c_x * c_x);
 
         let cell = Matrix3::new(a,   b_x, c_x,
                                 0.0, b_y, c_y,
@@ -167,9 +168,9 @@ impl UnitCell {
         let nb = (c ^ a).normalized();
         let nc = (a ^ b).normalized();
 
-        let x = f64::abs(na[0] * a[0] + na[1] * a[1] + na[2] * a[2]);
-        let y = f64::abs(nb[0] * b[0] + nb[1] * b[1] + nb[2] * b[2]);
-        let z = f64::abs(nc[0] * c[0] + nc[1] * c[1] + nc[2] * c[2]);
+        let x = abs(na[0] * a[0] + na[1] * a[1] + na[2] * a[2]);
+        let y = abs(nb[0] * b[0] + nb[1] * b[1] + nb[2] * b[2]);
+        let z = abs(nc[0] * c[0] + nc[1] * c[1] + nc[2] * c[2]);
 
         [x, y, z]
     }
@@ -265,15 +266,15 @@ impl UnitCell {
         match self.shape {
             CellShape::Infinite => (),
             CellShape::Orthorhombic => {
-                vect[0] -= f64::floor(vect[0] / self.a()) * self.a();
-                vect[1] -= f64::floor(vect[1] / self.b()) * self.b();
-                vect[2] -= f64::floor(vect[2] / self.c()) * self.c();
+                vect[0] -= floor(vect[0] / self.a()) * self.a();
+                vect[1] -= floor(vect[1] / self.b()) * self.b();
+                vect[2] -= floor(vect[2] / self.c()) * self.c();
             },
             CellShape::Triclinic => {
                 let mut fractional = self.fractional(vect);
-                fractional[0] -= f64::floor(fractional[0]);
-                fractional[1] -= f64::floor(fractional[1]);
-                fractional[2] -= f64::floor(fractional[2]);
+                fractional[0] -= floor(fractional[0]);
+                fractional[1] -= floor(fractional[1]);
+                fractional[2] -= floor(fractional[2]);
                 *vect = self.cartesian(&fractional);
             },
         }
@@ -286,15 +287,15 @@ impl UnitCell {
         match self.shape {
             CellShape::Infinite => (),
             CellShape::Orthorhombic => {
-                vect[0] -= f64::round(vect[0] / self.a()) * self.a();
-                vect[1] -= f64::round(vect[1] / self.b()) * self.b();
-                vect[2] -= f64::round(vect[2] / self.c()) * self.c();
+                vect[0] -= round(vect[0] / self.a()) * self.a();
+                vect[1] -= round(vect[1] / self.b()) * self.b();
+                vect[2] -= round(vect[2] / self.c()) * self.c();
             },
             CellShape::Triclinic => {
                 let mut fractional = self.fractional(vect);
-                fractional[0] -= f64::round(fractional[0]);
-                fractional[1] -= f64::round(fractional[1]);
-                fractional[2] -= f64::round(fractional[2]);
+                fractional[0] -= round(fractional[0]);
+                fractional[1] -= round(fractional[1]);
+                fractional[2] -= round(fractional[2]);
                 *vect = self.cartesian(&fractional);
             },
         }
@@ -330,7 +331,7 @@ impl UnitCell {
 
         let xn = x.normalized();
         let yn = y.normalized();
-        return f64::acos(xn * yn);
+        return acos(xn * yn);
     }
 
     /// Get the angle formed by the points at `a`, `b` and `c` using periodic
@@ -347,13 +348,13 @@ impl UnitCell {
         let yn = y.normalized();
 
         let cos = xn * yn;
-        let sin_inv = 1.0 / f64::sqrt(1.0 - cos * cos);
+        let sin_inv = 1.0 / sqrt(1.0 - cos * cos);
 
         let d1 = sin_inv * (cos * xn - yn) / x_norm;
         let d3 = sin_inv * (cos * yn - xn) / y_norm;
         let d2 = - (d1 + d3);
 
-        return (f64::acos(cos), d1, d2, d3);
+        return (acos(cos), d1, d2, d3);
     }
 
 
@@ -388,7 +389,7 @@ impl UnitCell {
         let norm2_x = x.norm2();
         let norm2_y = y.norm2();
         let norm2_r23 = r23.norm2();
-        let norm_r23 = f64::sqrt(norm2_r23);
+        let norm_r23 = sqrt(norm2_r23);
 
         let d1 = (-norm_r23 / norm2_x) * x;
         let d4 = (norm_r23 / norm2_y) * y;
@@ -408,7 +409,7 @@ impl UnitCell {
 fn angle(u: Vector3D, v: Vector3D) -> f64 {
     let un = u.normalized();
     let vn = v.normalized();
-    f64::acos(un * vn)
+    acos(un * vn)
 }
 
 #[cfg(test)]
@@ -581,7 +582,7 @@ mod tests {
         let cell = UnitCell::ortho(3.0, 4.0, 5.0);
         let u = &Vector3D::zero();
         let v = &Vector3D::new(1.0, 2.0, 6.0);
-        assert_eq!(cell.distance(u, v), f64::sqrt(6.0));
+        assert_eq!(cell.distance(u, v), sqrt(6.0));
 
         // Infinite unit cell
         let cell = UnitCell::new();
@@ -589,7 +590,7 @@ mod tests {
 
         // Triclinic unit cell
         let cell = UnitCell::triclinic(3.0, 4.0, 5.0, 90.0, 90.0, 90.0);
-        assert_eq!(cell.distance(u, v), f64::sqrt(6.0));
+        assert_eq!(cell.distance(u, v), sqrt(6.0));
     }
 
     #[test]
@@ -679,7 +680,7 @@ mod tests {
 
         let a = Vector3D::new(1.0, 0.0, 0.0);
         let b = Vector3D::zero();
-        let c = Vector3D::new(f64::cos(1.877), f64::sin(1.877), 0.0);
+        let c = Vector3D::new(cos(1.877), sin(1.877), 0.0);
         assert_eq!(cell.angle(&a, &b, &c), 1.877);
     }
 


### PR DESCRIPTION
This PR introduces a new `math` module at the root of lumol-core, containing functions like `abs`, `cos`, `exp`, ... that will allow to use said functions directly without needing the `f64::` prefix.