### PR TITLE
Update cleanup for cached tests executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - source scripts/ci/setup-travis.sh
     - ./scripts/ci/install-travis.sh
     # Clean any cached test executable
-    - rm -f target/debug/*-*
+    - find target/debug/deps/ ! -name "lib*" -type f -delete
 script:
     - cd $TRAVIS_BUILD_DIR
     # Run all tests in release mode


### PR DESCRIPTION
The code to find them was updated, but not the code to clean them from the Travis cache.

I was looking at the Travis logs from #196, and then I saw an error in the output: https://travis-ci.org/lumol-org/lumol/jobs/289677308#L5420-L5424. This should fix the error =)