### PR TITLE
Some refactoring of the MoveCounter struct

### DIFF
--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -72,11 +72,9 @@ impl MCMove for Resize {
         // Abort simulation when box gets smaller than twice the cutoff radius.
         if let Some(maximum_cutoff) = self.maximum_cutoff {
             if system.cell.lengths().iter().any(|&d| 0.5 * d <= maximum_cutoff) {
-                fatal_error!(
-                    "Tried to decrease the cell size but new size
-                    conflicts with the cut off radius. \
-                    Increase the number of particles to get rid of this problem."
-                );
+                fatal_error!("Tried to decrease the cell size but new size \
+                              conflicts with the cut off radius. Increase the number of \
+                              particles to get rid of this problem.");
             }
         };
 


### PR DESCRIPTION
This PR adds:
- some small functions to eliminate "manual tracking" of counters
- fixes a small bug where acceptance was always printed (`info!`) as zero if no updates where performed
- enhances docs and tests for `MoveCounter`   