### PR TITLE
Improve what we print to the logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ lumol-input = {path = "src/input"}
 lumol-core = {path = "src/core"}
 log = "0.3"
 clap = "2"
+chrono = "0.4"
 
 [dev-dependencies]
 bencher = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ documentation = "https://lumol-org.github.io/lumol"
 repository = "https://github.com/lumol-org/lumol"
 readme = "README.md"
 license = "BSD-3-Clause"
+build = "src/build.rs"
 
 [workspace]
 members = [

--- a/src/bin/lumol.rs
+++ b/src/bin/lumol.rs
@@ -1,5 +1,6 @@
 // Lumol, an extensible molecular simulation engine
 // Copyright (C) Lumol's contributors — BSD license
+extern crate lumol;
 extern crate lumol_input;
 
 #[macro_use]
@@ -11,7 +12,7 @@ use clap::{App, ArgMatches};
 
 fn parse_args<'a>() -> ArgMatches<'a> {
     App::new("lumol")
-        .version(env!("CARGO_PKG_VERSION"))
+        .version(lumol::VERSION)
         .about("An extensible molecular simulation engine")
         .args_from_usage("<input.toml>      'Simulation input file'")
         .get_matches()
@@ -27,6 +28,8 @@ fn main() {
             std::process::exit(2)
         }
     };
+
+    info!("Running lumol version {}", lumol::VERSION);
 
     config.simulation.run(&mut config.system, config.nsteps);
 }

--- a/src/bin/lumol.rs
+++ b/src/bin/lumol.rs
@@ -6,9 +6,12 @@ extern crate lumol_input;
 #[macro_use]
 extern crate log;
 extern crate clap;
+extern crate chrono;
 
 use lumol_input::Input;
 use clap::{App, ArgMatches};
+use chrono::offset::Local;
+use chrono::Duration;
 
 fn parse_args<'a>() -> ArgMatches<'a> {
     App::new("lumol")
@@ -31,5 +34,35 @@ fn main() {
 
     info!("Running lumol version {}", lumol::VERSION);
 
+    let start = Local::now();
+    info!("Simulation started the {} at {}", start.format("%Y-%m-%d"), start.format("%H:%M:%S"));
     config.simulation.run(&mut config.system, config.nsteps);
+
+    let end = Local::now();
+    info!("Simulation ended the {} at {}", end.format("%Y-%m-%d"), end.format("%H:%M:%S"));
+    let elapsed = end.signed_duration_since(start);
+    info!("Simulation ran for {}", format_elapsed(elapsed));
+}
+
+fn format_elapsed(elapsed: Duration) -> String {
+    if elapsed.num_weeks() > 0 {
+        let h = elapsed.num_hours() % 24;
+        let d = elapsed.num_days() % 7;
+        let w = elapsed.num_weeks();
+        format!("{} weeks {} days {}h", w, d, h)
+    } else if elapsed.num_days() > 0 {
+        let m = elapsed.num_minutes() % 60;
+        let h = elapsed.num_hours() % 24;
+        let d = elapsed.num_days();
+        format!("{} days {}h {}min", d, h, m)
+    } else if elapsed.num_hours() > 0 {
+        let s = elapsed.num_seconds() % 60;
+        let m = elapsed.num_minutes() % 60;
+        let h = elapsed.num_hours();
+        format!("{}h {}min {}s", h, m, s)
+    } else {
+        let s = elapsed.num_seconds() % 60;
+        let m = elapsed.num_minutes();
+        format!("{}min {}s", m, s)
+    }
 }

--- a/src/bin/lumol.rs
+++ b/src/bin/lumol.rs
@@ -36,10 +36,12 @@ fn main() {
 
     let start = Local::now();
     info!("Simulation started the {} at {}", start.format("%Y-%m-%d"), start.format("%H:%M:%S"));
+    info!(" "); // Skip a line
+
     config.simulation.run(&mut config.system, config.nsteps);
 
     let end = Local::now();
-    info!("Simulation ended the {} at {}", end.format("%Y-%m-%d"), end.format("%H:%M:%S"));
+    info!("\nSimulation ended the {} at {}", end.format("%Y-%m-%d"), end.format("%H:%M:%S"));
     let elapsed = end.signed_duration_since(start);
     info!("Simulation ran for {}", format_elapsed(elapsed));
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,17 @@
+use std::process::Command;
+use std::str;
+
+fn main() {
+    let mut version = env!("CARGO_PKG_VERSION").to_string();
+    match Command::new("git").args(&["describe", "--always"]).output() {
+        Ok(output) => {
+            let git = str::from_utf8(&output.stdout).unwrap().trim();
+            version.push_str("-");
+            version.push_str(git);
+        },
+        Err(_) => {}
+    }
+
+	println!("cargo:rustc-env=LUMOL_FULL_GIT_VERSION={}", version);
+	println!("cargo:rerun-if-changed=(nonexistentfile)");
+}

--- a/src/input/src/simulations/logging.rs
+++ b/src/input/src/simulations/logging.rs
@@ -123,8 +123,7 @@ impl Input {
             }
         } else {
             setup_default_logger();
-            info!("Logging to console as default.");
-            info!("You can configure logging in the [log] section of input file.");
+            info!("Printing logs to the console as default.");
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
 extern crate lumol_core;
 
+/// The full version of the crate, containing git state if available
+pub static VERSION: &'static str = env!("LUMOL_FULL_GIT_VERSION");
+
 pub use lumol_core::*;


### PR DESCRIPTION
This is a few improvements on what is printed to the log during a simulation.

For example, the argon tutorial printed this before:

```
Logging to console as default.
You can configure logging in the [log] section of input file.
Monte Carlo simulation summary
Statistics for move: molecular translation
  Attempts  : 100000
  Acceptance: 67.8780 %
```

And now outputs this:
```
Printing logs to the console as default.
Running lumol version 0.1.0-1df7ad546
Simulation started the 2017-11-01 at 22:03:51

Monte Carlo simulation summary
    molecular translation: 100000 attempts -- 67.9 % accepted

Simulation ended the 2017-11-01 at 22:03:54
Simulation ran for 0min 3s
```