### PR TITLE
Create a .nojekyll file at the root of gh-pages

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -11,7 +11,6 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.githubpages'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/scripts/ci/generate-docs.sh
+++ b/scripts/ci/generate-docs.sh
@@ -16,3 +16,5 @@ mv ../doc/* latest/
 cat <<EOF > index.html
 <meta http-equiv=refresh content=0;url=latest/index.html>
 EOF
+
+touch .nojekyll


### PR DESCRIPTION
Without it, github would not serve any file in a folder starting with _, which means that the book would not contains any JS or CSS