### PR TITLE
Ensure that we also print error messages with invalid TOML files

### DIFF
--- a/src/bin/lumol.rs
+++ b/src/bin/lumol.rs
@@ -22,8 +22,18 @@ fn parse_args<'a>() -> ArgMatches<'a> {
 
 fn main() {
     let args = parse_args();
+
     let input = args.value_of("input.toml").unwrap();
-    let mut config = match Input::new(input).and_then(|input| input.read()) {
+    let input = match Input::new(input) {
+        Ok(input) => input,
+        Err(err) => {
+            lumol_input::setup_default_logger();
+            error!("invalid input file: {}", err);
+            std::process::exit(2)
+        }
+    };
+
+    let mut config = match input.read() {
         Ok(config) => config,
         Err(err) => {
             error!("bad input file: {}", err);

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -85,6 +85,7 @@ mod simulations;
 pub use self::error::{Error, Result};
 pub use self::interactions::InteractionsInput;
 pub use self::simulations::{Config, Input};
+pub use self::simulations::setup_default_logger;
 
 /// Convert a TOML table to a Rust type.
 pub trait FromToml: Sized {

--- a/src/input/src/simulations/logging.rs
+++ b/src/input/src/simulations/logging.rs
@@ -128,7 +128,8 @@ impl Input {
     }
 }
 
-fn setup_default_logger() {
+/// Setup a default logger to be able to print error messages
+pub fn setup_default_logger() {
     // We just log everything to stdout
     let stdout = ConsoleAppender::builder().target(console::Target::Stdout)
                                            .encoder(Box::new(LogEncoder))

--- a/src/input/src/simulations/mod.rs
+++ b/src/input/src/simulations/mod.rs
@@ -22,6 +22,8 @@ mod min;
 mod md;
 mod mc;
 
+pub use self::logging::setup_default_logger;
+
 /// A configuration about how to run a single simulation. This contains the
 /// system to simulate, the simulation itself and the number of steps to run
 /// the simulation.


### PR DESCRIPTION
Previously, the logger was not initialized if the input file was invalid, which resulted in error messages not being printed.