### PR TITLE
Ewald: fix and improve parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 sudo: false
-dist: precise
 addons:
   apt:
     sources:
@@ -27,10 +26,10 @@ install:
 script:
     - cd $TRAVIS_BUILD_DIR
     # Run all tests in release mode
-    - cargo test --all --release
+    - cargo test --all --release -- --test-threads=2
     # Run unit tests and doc tests in debug mode
-    - cargo test -p lumol-core
-    - cargo test -p lumol-input
+    - cargo test -p lumol-core -- --test-threads=2
+    - cargo test -p lumol-input -- --test-threads=2
     # Check that benchmarks still compile
     - cargo bench --no-run
     # Check if tutorials compile

--- a/scripts/ci/install-travis.sh
+++ b/scripts/ci/install-travis.sh
@@ -16,4 +16,8 @@ fi
 
 cd $TRAVIS_BUILD_DIR
 
-pip install --user -r doc/requirements.txt
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    pip2 install --user -r doc/requirements.txt    
+else
+    pip install --user -r doc/requirements.txt
+fi

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -298,6 +298,7 @@ mod tests {
     pub use super::*;
     use energy::GlobalPotential;
     use sys::System;
+    use types::{Matrix3, One};
     use utils::system_from_xyz;
 
     const E_BRUTE_FORCE: f64 = -0.09262397663346732;
@@ -358,6 +359,44 @@ mod tests {
         let expected = Matrix3::new([[-force * 1.5, 0.0, 0.0], [0.0; 3], [0.0; 3]]);
 
         assert_eq!(wolf.virial(&system), expected);
+    }
+
+    #[test]
+    fn virial_finite_differences() {
+        fn scale(system: &mut System, i: usize, j: usize, eps: f64) {
+            let mut scaling = Matrix3::one();
+            scaling[i][j] += eps;
+            let old_cell = system.cell.clone();
+            let new_cell = system.cell.scale(scaling);
+
+            for position in system.particles_mut().position {
+                *position = new_cell.cartesian(&old_cell.fractional(&position));
+            }
+            system.cell = new_cell;
+        }
+
+        let eps = 1e-9;
+        let mut system = testing_system();
+        let wolf = Wolf::new(8.0);
+
+        let virial = wolf.virial(&system);
+
+        let mut finite_diff = Matrix3::zero();
+        let energy_0 = wolf.energy(&system);
+
+        scale(&mut system, 0, 0, eps);
+        let energy_1 = wolf.energy(&system);
+        finite_diff[0][0] = (energy_0 - energy_1) / eps;
+
+        scale(&mut system, 1, 0, eps);
+        let energy_2 = wolf.energy(&system);
+        finite_diff[1][0] = (energy_1 - energy_2) / eps;
+
+        scale(&mut system, 2, 0, eps);
+        let energy_3 = wolf.energy(&system);
+        finite_diff[2][0] = (energy_2 - energy_3) / eps;
+
+        assert_relative_eq!(virial, finite_diff, epsilon = 1e-5);
     }
 
     mod cache {

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -347,6 +347,19 @@ mod tests {
         assert_relative_eq!((e - e1) / eps, forces[0][0], epsilon = 1e-6);
     }
 
+    #[test]
+    fn virial() {
+        let system = testing_system();
+        let wolf = Wolf::new(8.0);
+
+        let mut forces = vec![Vector3D::zero(); system.size()];
+        wolf.forces(&system, &mut forces);
+        let force = forces[0][0];
+        let expected = Matrix3::new([[-force * 1.5, 0.0, 0.0], [0.0; 3], [0.0; 3]]);
+
+        assert_eq!(wolf.virial(&system), expected);
+    }
+
     mod cache {
         use super::*;
         use energy::{CoulombicPotential, GlobalCache, GlobalPotential, PairRestriction};

--- a/src/core/src/sys/config/cells.rs
+++ b/src/core/src/sys/config/cells.rs
@@ -97,19 +97,12 @@ impl UnitCell {
         self.shape
     }
 
-    /// Check if this unit cell is infinite, *i.e.* if it does not have periodic boundary
-    /// conditions.
+    /// Check if this unit cell is infinite, *i.e.* if it does not have
+    /// periodic boundary conditions.
     pub fn is_infinite(&self) -> bool {
         self.shape() == CellShape::Infinite
     }
 
-    /// Get the first vector of the cell
-    pub fn vect_a(&self) -> Vector3D {
-        let x = self.cell[0][0];
-        let y = self.cell[1][0];
-        let z = self.cell[2][0];
-        Vector3D::new(x, y, z)
-    }
     /// Get the first length of the cell (i.e. the norm of the first vector of
     /// the cell)
     pub fn a(&self) -> f64 {
@@ -119,14 +112,6 @@ impl UnitCell {
         }
     }
 
-    /// Get the second vector of the cell
-    pub fn vect_b(&self) -> Vector3D {
-        let x = self.cell[0][1];
-        let y = self.cell[1][1];
-        let z = self.cell[2][1];
-        Vector3D::new(x, y, z)
-    }
-
     /// Get the second length of the cell (i.e. the norm of the second vector of
     /// the cell)
     pub fn b(&self) -> f64 {
@@ -134,14 +119,6 @@ impl UnitCell {
             CellShape::Triclinic => self.vect_b().norm(),
             CellShape::Orthorhombic | CellShape::Infinite => self.cell[1][1],
         }
-    }
-
-    /// Get the third vector of the cell
-    pub fn vect_c(&self) -> Vector3D {
-        let x = self.cell[0][2];
-        let y = self.cell[1][2];
-        let z = self.cell[2][2];
-        Vector3D::new(x, y, z)
     }
 
     /// Get the third length of the cell (i.e. the norm of the third vector of
@@ -253,6 +230,35 @@ impl UnitCell {
         let rec_c = (2.0 * PI / volume) * (a ^ b);
 
         return (rec_a, rec_b, rec_c);
+    }
+
+    /// Get the matricial representation of the unit cell
+    pub fn matrix(&self) -> Matrix3 {
+        self.cell
+    }
+
+    /// Get the first vector of the cell
+    fn vect_a(&self) -> Vector3D {
+        let x = self.cell[0][0];
+        let y = self.cell[1][0];
+        let z = self.cell[2][0];
+        Vector3D::new(x, y, z)
+    }
+
+    /// Get the second vector of the cell
+    fn vect_b(&self) -> Vector3D {
+        let x = self.cell[0][1];
+        let y = self.cell[1][1];
+        let z = self.cell[2][1];
+        Vector3D::new(x, y, z)
+    }
+
+    /// Get the third vector of the cell
+    fn vect_c(&self) -> Vector3D {
+        let x = self.cell[0][2];
+        let y = self.cell[1][2];
+        let z = self.cell[2][2];
+        Vector3D::new(x, y, z)
     }
 }
 

--- a/src/input/tests/input.rs
+++ b/src/input/tests/input.rs
@@ -24,7 +24,10 @@ fn main() {
     env_logger::init().expect("could not set logger");
     let _cleanup = TestsCleanup;
 
-    let args: Vec<_> = env::args().collect();
+    let mut args: Vec<_> = env::args()
+                              .filter(|arg| !arg.contains("test-threads"))
+                              .collect();
+
     let mut opts = match test::parse_opts(&args).expect("no options") {
         Ok(opts) => opts,
         Err(msg) => panic!("{:?}", msg),

--- a/tests/data/md-nacl/ewald-kspace.toml
+++ b/tests/data/md-nacl/ewald-kspace.toml
@@ -1,0 +1,27 @@
+# A modified Ewald test, with ridiculously small real space cutoff, to increase
+# the effect of k-space energy/forces.
+
+[input]
+version = 1
+
+[global]
+cutoff = "11 A"
+
+[[pairs]]
+atoms = ["Na", "Cl"]
+lj = {sigma = "3.5545 A", epsilon = "0.04425 kcal/mol"}
+
+[[pairs]]
+atoms = ["Na", "Na"]
+lj = {sigma = "2.497 A", epsilon = "0.07826 kcal/mol"}
+
+[[pairs]]
+atoms = ["Cl", "Cl"]
+lj = {sigma = "4.612 A", epsilon = "0.02502 kcal/mol"}
+
+[coulomb]
+ewald = {cutoff = "1 A", kmax = 10}
+
+[charges]
+Na = 1.0
+Cl = -1.0

--- a/tests/data/md-nacl/nve-ewald-kspace.toml
+++ b/tests/data/md-nacl/nve-ewald-kspace.toml
@@ -1,0 +1,15 @@
+[input]
+version = 1
+
+[[systems]]
+file = "small.xyz"
+cell = 11.2804
+potentials = "ewald-kspace.toml"
+velocities = {init = "300 K"}
+
+[[simulations]]
+nsteps = 100
+
+[simulations.propagator]
+type = "MolecularDynamics"
+timestep = "1 fs"

--- a/tests/md-nacl.rs
+++ b/tests/md-nacl.rs
@@ -90,6 +90,24 @@ mod ewald {
     }
 
     #[test]
+    fn constant_energy_kspace() {
+        START.call_once(|| {
+            ::env_logger::init().unwrap();
+        });
+        let path = Path::new(file!()).parent()
+                                     .unwrap()
+                                     .join("data")
+                                     .join("md-nacl")
+                                     .join("nve-ewald-kspace.toml");
+        let mut config = Input::new(path).unwrap().read().unwrap();
+
+        let e_initial = config.system.total_energy();
+        config.simulation.run(&mut config.system, config.nsteps);
+        let e_final = config.system.total_energy();
+        assert!(f64::abs((e_initial - e_final) / e_final) < 5e-3);
+    }
+
+    #[test]
     fn energy() {
         START.call_once(|| {
             ::env_logger::init().unwrap();


### PR DESCRIPTION
This PR contains a few fixes for bugs I found while working on #225.

While looking at the Ewald code, I found why @antoinewdg could not get a very good speedup when parallelizing Ewald: the real space code (which is ~50% of the time) was not parallel at all =) So the last commit in this PR uses Rayon to make the real space energy/forces/virial parallel.