### PR TITLE
Error when using potentials with a too small cutoff 

### DIFF
--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -43,7 +43,7 @@ use super::{GlobalPotential, CoulombicPotential, GlobalCache};
 /// use lumol_core::types::Vector3D;
 ///
 /// // Setup a system containing a NaCl pair
-/// let mut system = System::with_cell(UnitCell::cubic(10.0));
+/// let mut system = System::with_cell(UnitCell::cubic(30.0));
 ///
 /// let mut na = Particle::new("Na");
 /// na.charge = 1.0;
@@ -59,7 +59,7 @@ use super::{GlobalPotential, CoulombicPotential, GlobalCache};
 /// // Use Ewald summation for electrostatic interactions
 /// system.set_coulomb_potential(Box::new(ewald));
 ///
-/// assert_eq!(system.potential_energy(), -0.07042996180522723);
+/// assert_eq!(system.potential_energy(), -0.06951109741775707);
 /// ```
 ///
 /// [FS2002] Frenkel, D. & Smith, B. Understanding molecular simulation. (Academic press, 2002).

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -32,7 +32,7 @@ use super::{CoulombicPotential, GlobalCache, GlobalPotential};
 /// use lumol_core::types::Vector3D;
 ///
 /// // Setup a system containing a NaCl pair
-/// let mut system = System::with_cell(UnitCell::cubic(10.0));
+/// let mut system = System::with_cell(UnitCell::cubic(30.0));
 ///
 /// let mut na = Particle::new("Na");
 /// na.charge = 1.0;

--- a/src/core/src/energy/pairs.rs
+++ b/src/core/src/energy/pairs.rs
@@ -336,7 +336,7 @@ mod tests {
         };
         let pairs = PairInteraction::shifted(Box::new(lj), 4.0);
 
-        assert_eq!(pairs.force(2.5), lj.force(2.5));
+        assert_ulps_eq!(pairs.force(2.5), lj.force(2.5));
         assert_ulps_eq!(pairs.energy(2.5), -0.030681134109158216);
 
         assert_eq!(pairs.force(4.1), 0.0);

--- a/src/core/src/sim/mc/moves/resize.rs
+++ b/src/core/src/sim/mc/moves/resize.rs
@@ -73,9 +73,10 @@ impl MCMove for Resize {
         if let Some(maximum_cutoff) = self.maximum_cutoff {
             if system.cell.lengths().iter().any(|&d| 0.5 * d <= maximum_cutoff) {
                 fatal_error!(
-                    "Tried to decrease the cell size but new size \
-                     conflicts with the cut off radius. Increase the number of \
-                     particles to get rid of this problem."
+                    "Tried to decrease the cell size in Monte Carlo Resize move \
+                     but the new size is smaller than the interactions cut off \
+                     radius. You can try to increase the cell size or the number \
+                     of particles."
                 );
             }
         };

--- a/src/core/src/sys/cache.rs
+++ b/src/core/src/sys/cache.rs
@@ -441,7 +441,7 @@ mod tests {
             }),
         );
 
-        system.set_coulomb_potential(Box::new(Wolf::new(8.0)));
+        system.set_coulomb_potential(Box::new(Wolf::new(5.0)));
 
         for particle in system.particles_mut() {
             if particle.name == "O" {

--- a/src/core/src/sys/config/cells.rs
+++ b/src/core/src/sys/config/cells.rs
@@ -132,7 +132,9 @@ impl UnitCell {
 
     /// Get the distances between faces of the unit cell
     pub fn lengths(&self) -> [f64; 3] {
-        assert_ne!(self.shape, CellShape::Infinite);
+        if self.shape == CellShape::Infinite {
+            return [f64::INFINITY; 3];
+        }
 
         let (a, b, c) = (self.vect_a(), self.vect_b(), self.vect_c());
         // Plans normal vectors

--- a/src/core/src/sys/config/cells.rs
+++ b/src/core/src/sys/config/cells.rs
@@ -4,6 +4,7 @@
 //! Simulations in computational chemistry are often made using periodic
 //! boundaries conditions. The `UnitCell` type represents the enclosing box of
 //! a simulated system, with some type of periodic condition.
+use std::f64;
 use std::f64::consts::PI;
 
 use math::*;

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -144,6 +144,13 @@ impl System {
 
     /// Add the `potential` pair interaction for atoms with types `i` and `j`
     pub fn add_pair_potential(&mut self, (i, j): (&str, &str), potential: PairInteraction) {
+        if self.cell.lengths().iter().any(|&d| 0.5 * d < potential.cutoff()) {
+            fatal_error!(
+                "Can not add a potential with a cutoff bigger than half of the \
+                smallest cell length. Try increasing the cell size or decreasing \
+                the cutoff."
+            );
+        }
         let kind_i = self.get_kind(i);
         let kind_j = self.get_kind(j);
         self.interactions.add_pair((kind_i, kind_j), potential)
@@ -184,6 +191,15 @@ impl System {
 
     /// Set the coulombic interaction for all pairs to `potential`
     pub fn set_coulomb_potential(&mut self, potential: Box<CoulombicPotential>) {
+        if let Some(cutoff) = potential.cutoff() {
+            if self.cell.lengths().iter().any(|&d| 0.5 * d < cutoff) {
+                fatal_error!(
+                    "Can not add a potential with a cutoff bigger than half of the \
+                    smallest cell length. Try increasing the cell size or decreasing \
+                    the cutoff."
+                );
+            }
+        }
         self.interactions.coulomb = Some(potential);
     }
 

--- a/src/input/tests/input.rs
+++ b/src/input/tests/input.rs
@@ -24,9 +24,9 @@ fn main() {
     env_logger::init().expect("could not set logger");
     let _cleanup = TestsCleanup;
 
-    let mut args: Vec<_> = env::args()
-                              .filter(|arg| !arg.contains("test-threads"))
-                              .collect();
+    let args: Vec<_> = env::args()
+                           .filter(|arg| !arg.contains("test-threads"))
+                           .collect();
 
     let mut opts = match test::parse_opts(&args).expect("no options") {
         Ok(opts) => opts,

--- a/src/input/tests/simulation/good/system.toml
+++ b/src/input/tests/simulation/good/system.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [[systems]]
-cell = 20
+cell = 50.0
 file = "../CO2.xyz"
 guess_bonds = true
 velocities = {init = "300 K"}

--- a/tests/data/mc-water/ewald.toml
+++ b/tests/data/mc-water/ewald.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [global]
-cutoff = "14 A"
+cutoff = "9 A"
 
 # f-SPC model of water, using ewald summation for electrostatics
 [[pairs]]

--- a/tests/data/mc-water/wolf.toml
+++ b/tests/data/mc-water/wolf.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [global]
-cutoff = "14 A"
+cutoff = "9 A"
 
 # f-SPC model of water, using ewald summation for electrostatics
 [[pairs]]

--- a/tests/data/md-helium/npt-berendsen-barostat.toml
+++ b/tests/data/md-helium/npt-berendsen-barostat.toml
@@ -9,7 +9,7 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = "10 A"
+cutoff = "4.5 A"
 
 [[simulations]]
 nsteps = 5_000

--- a/tests/data/md-helium/nve-leap-frog.toml
+++ b/tests/data/md-helium/nve-leap-frog.toml
@@ -9,7 +9,7 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = "10 A"
+cutoff = "4.5 A"
 
 [[simulations]]
 nsteps = 1_000

--- a/tests/data/md-helium/nve-perfect-gas.toml
+++ b/tests/data/md-helium/nve-perfect-gas.toml
@@ -9,7 +9,7 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = "10 A"
+cutoff = "4.5 A"
 
 [[simulations]]
 nsteps = 1_000

--- a/tests/data/md-helium/nve-shifted.toml
+++ b/tests/data/md-helium/nve-shifted.toml
@@ -9,7 +9,7 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = {shifted = "7 A"}
+cutoff = {shifted = "4.5 A"}
 
 [[simulations]]
 nsteps = 1_000

--- a/tests/data/md-helium/nve-table.toml
+++ b/tests/data/md-helium/nve-table.toml
@@ -9,8 +9,8 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = "7 A"
-computation = {table = {max = "7 A", n = 1000}}
+cutoff = "4.5 A"
+computation = {table = {max = "5 A", n = 1000}}
 
 [[simulations]]
 nsteps = 1_000

--- a/tests/data/md-helium/nve-velocity-verlet.toml
+++ b/tests/data/md-helium/nve-velocity-verlet.toml
@@ -9,7 +9,7 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = "10 A"
+cutoff = "4.5 A"
 
 [[simulations]]
 nsteps = 1_000

--- a/tests/data/md-helium/nve-verlet.toml
+++ b/tests/data/md-helium/nve-verlet.toml
@@ -9,7 +9,7 @@ velocities = {init = "300 K"}
 [[systems.potentials.pairs]]
 atoms = ["He", "He"]
 lj = {sigma = "2 A", epsilon = "0.2 kJ/mol"}
-cutoff = "10 A"
+cutoff = "4.5 A"
 
 [[simulations]]
 nsteps = 1_000

--- a/tests/data/md-nacl/ewald-kspace.toml
+++ b/tests/data/md-nacl/ewald-kspace.toml
@@ -5,7 +5,7 @@
 version = 1
 
 [global]
-cutoff = "11 A"
+cutoff = "5.5 A"
 
 [[pairs]]
 atoms = ["Na", "Cl"]

--- a/tests/data/md-nacl/ewald.toml
+++ b/tests/data/md-nacl/ewald.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [global]
-cutoff = "11 A"
+cutoff = "5.5 A"
 
 [[pairs]]
 atoms = ["Na", "Cl"]

--- a/tests/data/md-nacl/wolf.toml
+++ b/tests/data/md-nacl/wolf.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [global]
-cutoff = "11 A"
+cutoff = "5.5 A"
 
 [[pairs]]
 atoms = ["Na", "Cl"]

--- a/tests/md-helium.rs
+++ b/tests/md-helium.rs
@@ -33,7 +33,7 @@ fn constant_energy_velocity_verlet() {
     let e_initial = config.system.total_energy();
     config.simulation.run(&mut config.system, config.nsteps);
     let e_final = config.system.total_energy();
-    assert!(f64::abs((e_initial - e_final) / e_final) < 1e-3);
+    assert!(f64::abs((e_initial - e_final) / e_final) < 2e-3);
 }
 
 
@@ -71,7 +71,7 @@ fn constant_energy_leap_frog() {
     let e_initial = config.system.total_energy();
     config.simulation.run(&mut config.system, config.nsteps);
     let e_final = config.system.total_energy();
-    assert!(f64::abs((e_initial - e_final) / e_final) < 1e-3);
+    assert!(f64::abs((e_initial - e_final) / e_final) < 2e-3);
 }
 
 #[test]
@@ -158,5 +158,5 @@ fn table_computation() {
     let e_initial = config.system.total_energy();
     config.simulation.run(&mut config.system, config.nsteps);
     let e_final = config.system.total_energy();
-    assert!(f64::abs((e_initial - e_final) / e_final) < 2e-3);
+    assert!(f64::abs((e_initial - e_final) / e_final) < 5e-3);
 }

--- a/tests/md-nacl.rs
+++ b/tests/md-nacl.rs
@@ -33,7 +33,7 @@ mod wolf {
         config.simulation.run(&mut config.system, config.nsteps);
 
         let e_final = config.system.total_energy();
-        assert!(f64::abs((e_initial - e_final) / e_final) < 1e-6);
+        assert!(f64::abs((e_initial - e_final) / e_final) < 1e-4);
     }
 
     #[test]
@@ -57,7 +57,7 @@ mod wolf {
 
         let expected = units::from(50000.0, "bar").unwrap();
         let pressure = ::utils::mean(pressures.clone());
-        assert!(f64::abs(pressure - expected) / expected < 1e-3);
+        assert!(f64::abs(pressure - expected) / expected < 2e-3);
 
         let expected = units::from(273.0, "K").unwrap();
         let temperature = ::utils::mean(temperatures.clone());
@@ -122,6 +122,6 @@ mod ewald {
 
         // Energy of this system given by LAMMPS in kcal/mol
         const LAMMPS_ENERGY: f64 = -48610.136;
-        assert!(f64::abs((energy - LAMMPS_ENERGY) / LAMMPS_ENERGY) < 1e-3);
+        assert!(f64::abs((energy - LAMMPS_ENERGY) / LAMMPS_ENERGY) < 2e-3);
     }
 }

--- a/tutorials/potential/src/main.rs
+++ b/tutorials/potential/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     // use tail corrections to account for our truncation
     pairs.enable_tail_corrections();
     // finally add this interaction to the system for Argon atoms
-    system.add_pair_potential("Ar", "Ar", pairs);
+    system.add_pair_potential(("Ar", "Ar"), pairs);
 
     // report the initial system energy
     let ener_init = units::to(system.total_energy(), "kJ/mol").unwrap();


### PR DESCRIPTION
Using potentials with a cutoff bigger than half the cell is not well defined with the current code, so this PR adds `fatal_error` in NPT MD integrator when resizing the cell to a small value, and when adding potentials to a system. 

NPT MC integrator already call `fatal_error`.

See #232 for initial discussion on this.

We could return `Result` instead of `panic!`ing  in `System::add_pair_potential`, but I am not really sure is it worth it: what could the user do with the Error case ?