### PR TITLE
Add iteration on Composition, remove System::particle_kinds()

### DIFF
--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -199,12 +199,11 @@ impl Compute for Virial {
         // Tail correction for pair potentials contribution
         let volume = system.cell.volume();
         let composition = system.composition();
-        for i in system.particle_kinds() {
-            let ni = composition[i] as f64;
-            for j in system.particle_kinds() {
-                let nj = composition[j] as f64;
+        for (i, &ni) in &composition {
+            for (j, &nj) in &composition {
+                let two_pi_density = 2.0 * PI * (ni as f64) * (nj as f64) / volume;
                 for potential in system.interactions().pairs((i, j)) {
-                    virial += 2.0 * PI * ni * nj * potential.tail_virial() / volume;
+                    virial += two_pi_density * potential.tail_virial();
                 }
             }
         }

--- a/src/core/src/sys/config/configuration.rs
+++ b/src/core/src/sys/config/configuration.rs
@@ -309,13 +309,13 @@ impl Configuration {
     /// index.
     ///
     /// For example, if we have
-    /// ```
+    /// ```text
     ///  0    1    2    3   # Molecules indexes
     /// H-H  H-H  H-H  H-H
     /// 0 1  2 3  4 5  6 7  # Particles indexes
     /// ```
     /// and call `merge_molecules(0, 3)` the result will be
-    /// ```
+    /// ```text
     /// 0 1 6 7  2 3  4 5  # Old indexes
     /// H-H-H-H  H-H  H-H
     /// 0 1 2 3  4 5  6 7  # New indexes

--- a/src/core/src/sys/energy.rs
+++ b/src/core/src/sys/energy.rs
@@ -62,12 +62,11 @@ impl<'a> EnergyEvaluator<'a> {
         let mut energy = 0.0;
         let volume = self.system.volume();
         let composition = self.system.composition();
-        for i in self.system.particle_kinds() {
-            let ni = composition[i] as f64;
-            for j in self.system.particle_kinds() {
-                let nj = composition[j] as f64;
+        for (i, &ni) in &composition {
+            for (j, &nj) in &composition {
+                let two_pi_density = 2.0 * PI * (ni as f64) * (nj as f64) / volume;
                 for potential in self.system.interactions().pairs((i, j)) {
-                    energy += 2.0 * PI * ni * nj * potential.tail_energy() / volume;
+                    energy += two_pi_density * potential.tail_energy();
                 }
             }
         }

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -90,11 +90,6 @@ impl System {
         return composition;
     }
 
-    /// Get a list of all the particles kinds in the system.
-    pub fn particle_kinds(&self) -> Vec<ParticleKind> {
-        self.kinds.values().cloned().collect()
-    }
-
     /// Get the current step of the system
     pub fn step(&self) -> u64 {
         self.step
@@ -442,24 +437,6 @@ mod tests {
         assert_eq!(system.particles().kind[0], ParticleKind(0));
         assert_eq!(system.particles().kind[1], ParticleKind(1));
         assert_eq!(system.particles().kind[2], ParticleKind(0));
-    }
-
-    #[test]
-    fn particle_kinds() {
-        let mut system = System::new();
-        system.add_particle(Particle::new("H"));
-        system.add_particle(Particle::new("O"));
-        system.add_particle(Particle::new("O"));
-        system.add_particle(Particle::new("H"));
-        system.add_particle(Particle::new("C"));
-        system.add_particle(Particle::new("U"));
-
-        let kinds = system.particle_kinds();
-        assert_eq!(kinds.len(), 4);
-        assert!(kinds.contains(&ParticleKind(0)));
-        assert!(kinds.contains(&ParticleKind(1)));
-        assert!(kinds.contains(&ParticleKind(2)));
-        assert!(kinds.contains(&ParticleKind(3)));
     }
 
     #[test]


### PR DESCRIPTION
We already know which particle kinds exist from the size of the composition, so there is no need for a separated function on `System`