### PR TITLE
Set Ewald parameters from a given precision

### DIFF
--- a/doc/src/input/systems/interactions/electrostatic.rst
+++ b/doc/src/input/systems/interactions/electrostatic.rst
@@ -50,25 +50,29 @@ file:
 .. code::
 
     [coulomb]
-    ewald = {cutoff = "9 A", kmax = 7}
+    ewald = {cutoff = "9 A", accuracy = 1e-5}
 
 The ``cutoff`` parameter specifies the cutoff distance for the short-range and
-long-range interactions splitting. The ``kmax`` parameter gives the number of
-vector to use in the reciprocal space (the long-range part of interactions).
-Usually 7-8 is a good value for pure water, for a very periodic charges
-distribution (like a crystal) a lower value, such as 5 is sufficient, and for
-more heterogeneous system, higher values of ``kmax`` are needed.
+long-range interactions splitting. The ``accuracy`` parameter is used to request
+a relative relative error in forces, and should be smaller than 1. The
+``accuracy`` is used to set the other Ewald parameters (alpha and kmax).
 
-It is also possible (but not required) to set the ``alpha`` parameter of Ewald
-solver directly with the corresponding keyword. A good value of ``alpha`` is one
-that satisfies :math:`\exp \left(-\alpha \frac L 2 \right) << 1`. If no value is
-provided in the input file, the default value of :math:`\pi / \text{cutoff}` is
-used.
+It is also possible to manually set the Ewald parameters:
 
 .. code::
 
     [coulomb]
-    ewald = {cutoff = "9 A", kmax = 7, alpha = "0.33451"}
+    ewald = {cutoff = "9 A", kmax = 7, alpha = 0.33451}
+
+The ``kmax`` parameter gives the number of points to use in the reciprocal space
+(the long-range part of interactions). Usually 7-8 is a good value for pure
+water, for a very periodic charges distribution (like a crystal) a lower value,
+such as 5 is sufficient, and for more heterogeneous system, higher values of
+``kmax`` are needed. The ``alpha`` parameter specifies the width of the charges
+spreading used to smooth the distribution in reciprocal space. A good value of
+``alpha`` is one that satisfies :math:`\exp \left(-\alpha \frac L 2 \right) <<
+1`. If only ``kmax`` is provided in the input file, the default value of
+:math:`\pi / \text{cutoff}` is used for ``alpha``.
 
 Wolf solver
 -----------

--- a/doc/src/input/systems/interactions/electrostatic.rst
+++ b/doc/src/input/systems/interactions/electrostatic.rst
@@ -62,7 +62,7 @@ It is also possible to manually set the Ewald parameters:
 .. code::
 
     [coulomb]
-    ewald = {cutoff = "9 A", kmax = 7, alpha = 0.33451}
+    ewald = {cutoff = "9 A", kmax = 7, alpha = "0.33451 A^-1"}
 
 The ``kmax`` parameter gives the number of points to use in the reciprocal space
 (the long-range part of interactions). Usually 7-8 is a good value for pure

--- a/src/input/src/interactions/coulomb.rs
+++ b/src/input/src/interactions/coulomb.rs
@@ -8,6 +8,7 @@ use lumol::sys::System;
 use super::InteractionsInput;
 use super::read_restriction;
 use FromToml;
+use FromTomlWithRefData;
 use error::{Error, Result};
 
 impl InteractionsInput {
@@ -18,11 +19,9 @@ impl InteractionsInput {
             None => return Ok(()),
         };
 
-        let coulomb =
-            try!(coulomb.as_table().ok_or(Error::from("The 'coulomb' section must be a table")));
+        let coulomb = coulomb.as_table().ok_or(Error::from("The 'coulomb' section must be a table"))?;
 
-        let solvers =
-            coulomb.keys().cloned().filter(|key| key != "restriction").collect::<Vec<_>>();
+        let solvers = coulomb.keys().cloned().filter(|key| key != "restriction").collect::<Vec<_>>();
 
         if solvers.len() != 1 {
             return Err(Error::from(
@@ -35,7 +34,7 @@ impl InteractionsInput {
             let mut potential: Box<CoulombicPotential> = match key {
                 "wolf" => Box::new(try!(Wolf::from_toml(table))),
                 "ewald" => {
-                    let ewald = try!(Ewald::from_toml(table));
+                    let ewald = try!(Ewald::from_toml(table, &system));
                     Box::new(SharedEwald::new(ewald))
                 }
                 other => return Err(Error::from(format!("Unknown coulomb solver '{}'", other))),

--- a/src/input/src/interactions/mod.rs
+++ b/src/input/src/interactions/mod.rs
@@ -52,8 +52,9 @@ impl InteractionsInput {
         try!(self.read_bonds(system));
         try!(self.read_angles(system));
         try!(self.read_dihedrals(system));
-        try!(self.read_coulomb(system));
+        // charges must be read before coulomb
         try!(self.read_charges(system));
+        try!(self.read_coulomb(system));
         Ok(())
     }
 }

--- a/src/input/src/interactions/toml.rs
+++ b/src/input/src/interactions/toml.rs
@@ -187,7 +187,8 @@ impl FromTomlWithRefData for Ewald {
         // Else use directly specified parameters
         let kmax = extract::uint("kmax", table, "Ewald coulombic potential")?;
         let alpha = if table.contains_key("alpha") {
-            Some(extract::number("alpha", table, "Ewald coulombic potential")?)
+            let alpha = extract::str("alpha", table, "Ewald coulombic potential")?;
+            Some(units::from_str(alpha)?)
         } else {
             None
         };

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -93,12 +93,20 @@ pub trait FromToml: Sized {
     fn from_toml(table: &Table) -> Result<Self>;
 }
 
-/// Convert a TOML table and some additional data to a Rust type.
+/// Convert a TOML table and some additional owned data to a Rust type.
 pub trait FromTomlWithData: Sized {
     /// The type of the additional data needed.
     type Data;
     /// Do the conversion from `table` and `data` to Self.
     fn from_toml(table: &Table, data: Self::Data) -> Result<Self>;
+}
+
+/// Convert a TOML table to a Rust type using information from an additional reference.
+pub trait FromTomlWithRefData: Sized {
+    /// The type of the additional data needed.
+    type Data;
+    /// Do the conversion from `table` and `data` to Self.
+    fn from_toml(table: &Table, data: &Self::Data) -> Result<Self>;
 }
 
 fn validate(config: &Table) -> Result<()> {

--- a/src/input/tests/interactions/bad/coulomb.toml
+++ b/src/input/tests/interactions/bad/coulomb.toml
@@ -49,7 +49,7 @@ version = 1
 
 [coulomb]
 ewald = {cutoff = "6 A", kmax = 7, alpha = false}
-#^ 'alpha' must be a number in Ewald coulombic potential
+#^ 'alpha' must be a string in Ewald coulombic potential
 
 +++
 

--- a/src/input/tests/interactions/bad/coulomb.toml
+++ b/src/input/tests/interactions/bad/coulomb.toml
@@ -52,6 +52,7 @@ ewald = {cutoff = "6 A", kmax = 7, alpha = false}
 #^ 'alpha' must be a number in Ewald coulombic potential
 
 +++
+
 [input]
 version = 1
 
@@ -76,3 +77,21 @@ version = 1
 [coulomb]
 unknown = {}
 #^ Unknown coulomb solver 'unknown'
+
++++
+
+[input]
+version = 1
+
+[coulomb]
+ewald = {cutoff = "6 A", kmax = 7, accuracy = 12}
+#^ can not have both accuracy and kmax/alpha in Ewald coulombic potential
+
++++
+
+[input]
+version = 1
+
+[coulomb]
+ewald = {cutoff = "6 A", accuracy = false}
+#^ 'accuracy' must be a number in Ewald coulombic potential

--- a/src/input/tests/interactions/good/ewald.toml
+++ b/src/input/tests/interactions/good/ewald.toml
@@ -20,3 +20,15 @@ ewald = {cutoff = "189 A", kmax = 112, alpha = 0.28}
 [charges]
 A = -8
 B = 3
+
++++
+
+[input]
+version = 1
+
+[coulomb]
+ewald = {cutoff = "19 A", accuracy = 1e-6}
+
+[charges]
+A = -8
+B = 3

--- a/src/input/tests/interactions/good/ewald.toml
+++ b/src/input/tests/interactions/good/ewald.toml
@@ -15,7 +15,7 @@ B = 3
 version = 1
 
 [coulomb]
-ewald = {cutoff = "189 A", kmax = 112, alpha = 0.28}
+ewald = {cutoff = "189 A", kmax = 112, alpha = "0.28 A^-1"}
 
 [charges]
 A = -8


### PR DESCRIPTION
The user should provide the cutoff and desired accuracy, and we compute optimal values for alpha and kmax from there. 

I took the algorithm to select alpha/kmax from LAMMPS.

Fix #183 
Fix #119