### PR TITLE
Better molecules type

### DIFF
--- a/benches/propane.rs
+++ b/benches/propane.rs
@@ -46,14 +46,14 @@ fn cache_move_particles(bencher: &mut Bencher) {
         145, 59, 58, 50, 238, 182, 97, 28, 107, 149, 227, 40, 90, 109, 196, 129
     ]);
 
-    let molecule = rng.choose(system.molecules()).unwrap();
-    let indexes = molecule.into_iter();
+    let molid = rng.gen_range(0, system.molecules_count());
+    let molecule = system.molecule(molid);
     let mut delta = vec![];
-    for position in &system.particles().position[indexes] {
+    for position in molecule.particles().position {
         delta.push(position + Vector3D::new(rng.gen(), rng.gen(), rng.gen()));
     }
 
-    bencher.iter(|| cache.move_particles_cost(&system, molecule.iter().collect(), &delta))
+    bencher.iter(|| cache.move_particles_cost(&system, molecule.indexes().collect(), &delta))
 }
 
 fn cache_move_all_rigid_molecules(bencher: &mut Bencher) {
@@ -65,10 +65,9 @@ fn cache_move_all_rigid_molecules(bencher: &mut Bencher) {
         106, 32, 216, 89, 97, 75, 51, 16, 90, 137, 27, 66, 167, 233, 109, 177
     ]);
 
-    for molecule in system.molecules().to_owned() {
+    for mut molecule in system.molecules_mut() {
         let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
-        let indexes = molecule.into_iter();
-        for position in &mut system.particles_mut().position[indexes] {
+        for position in molecule.particles_mut().position {
             *position += delta;
         }
     }

--- a/benches/water.rs
+++ b/benches/water.rs
@@ -69,16 +69,16 @@ mod ewald {
             206, 1, 245, 36, 62, 147, 30, 213, 177, 131, 94, 148, 239, 154, 161, 1
         ]);
 
-        let molecule = rng.choose(system.molecules()).unwrap();
-        let indexes = molecule.into_iter();
+        let molid = rng.gen_range(0, system.molecules_count());
+        let molecule = system.molecule(molid);
         let mut delta = vec![];
-        for position in &system.particles().position[indexes] {
+        for position in molecule.particles().position {
             delta.push(position + Vector3D::new(rng.gen(), rng.gen(), rng.gen()));
         }
 
-        cache.move_particles_cost(&system, molecule.iter().collect(), &delta);
+        cache.move_particles_cost(&system, molecule.indexes().collect(), &delta);
 
-        bencher.iter(|| cache.move_particles_cost(&system, molecule.iter().collect(), &delta))
+        bencher.iter(|| cache.move_particles_cost(&system, molecule.indexes().collect(), &delta))
     }
 
     pub fn cache_move_all_rigid_molecules(bencher: &mut Bencher) {
@@ -92,10 +92,9 @@ mod ewald {
             79, 129, 118, 38, 44, 204, 227, 6, 233, 6, 7, 216, 192, 77, 33, 85
         ]);
 
-        for molecule in system.molecules().to_owned() {
+        for mut molecule in system.molecules_mut() {
             let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
-            let indexes = molecule.into_iter();
-            for position in &mut system.particles_mut().position[indexes] {
+            for position in molecule.particles_mut().position {
                 *position += delta;
             }
         }
@@ -164,16 +163,16 @@ mod wolf {
             215, 235, 194, 22, 205, 151, 210, 241, 188, 67, 241, 2, 204, 62, 11, 201
         ]);
 
-        let molecule = rng.choose(system.molecules()).unwrap();
-        let indexes = molecule.into_iter();
+        let molid = rng.gen_range(0, system.molecules_count());
+        let molecule = system.molecule(molid);
         let mut delta = vec![];
-        for position in &system.particles().position[indexes] {
+        for position in molecule.particles().position {
             delta.push(position + Vector3D::new(rng.gen(), rng.gen(), rng.gen()));
         }
 
-        cache.move_particles_cost(&system, molecule.iter().collect(), &delta);
+        cache.move_particles_cost(&system, molecule.indexes().collect(), &delta);
 
-        bencher.iter(|| cache.move_particles_cost(&system, molecule.iter().collect(), &delta))
+        bencher.iter(|| cache.move_particles_cost(&system, molecule.indexes().collect(), &delta))
     }
 
     pub fn cache_move_all_rigid_molecules(bencher: &mut Bencher) {
@@ -187,10 +186,9 @@ mod wolf {
             89, 208, 141, 72, 208, 131, 249, 179, 77, 243, 111, 32, 176, 194, 79, 44
         ]);
 
-        for molecule in system.molecules().to_owned() {
+        for mut molecule in system.molecules_mut() {
             let delta = Vector3D::new(rng.gen(), rng.gen(), rng.gen());
-            let indexes = molecule.into_iter();
-            for position in &mut system.particles_mut().position[indexes] {
+            for position in molecule.particles_mut().position {
                 *position += delta;
             }
         }

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 1.6
+sphinx ==1.7.9
 sphinx_rtd_theme
 pygments
 toml

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -7,8 +7,8 @@ extern crate lumol_input as input;
 
 use lumol::sim::Simulation;
 use lumol::sim::mc::{MonteCarlo, Rotate, Translate};
-use lumol::sys::{Molecule, Particle, ParticleVec, TrajectoryBuilder, UnitCell};
-use lumol::sys::{molecule_type, read_molecule};
+use lumol::sys::{Molecule, Particle, TrajectoryBuilder, UnitCell};
+use lumol::sys::read_molecule;
 use lumol::units;
 
 use input::InteractionsInput;
@@ -18,7 +18,7 @@ fn main() {
                                              .and_then(|mut traj| traj.read())
                                              .unwrap();
     // Add bonds in the system
-    for i in 0..system.molecules().len() / 3 {
+    for i in 0..system.molecules_count() / 3 {
         system.add_bond(3 * i, 3 * i + 1);
         system.add_bond(3 * i + 1, 3 * i + 2);
     }
@@ -27,26 +27,19 @@ fn main() {
     let input = InteractionsInput::new("data/binary.toml").unwrap();
     input.read(&mut system).unwrap();
 
-    let co2 = {
-        // We can read files to get molecule type
-        let (molecule, atoms) = read_molecule("data/CO2.xyz").unwrap();
-        molecule_type(&molecule, atoms.as_slice())
-    };
+    // We can read files to get molecule type
+    let co2 = read_molecule("data/CO2.xyz").unwrap().molecule_type();
+
+    // Or define a new molecule by hand
     let h2o = {
-        // Or define a new molecule by hand
-        let mut molecule = Molecule::new(0);
-        molecule.merge_with(Molecule::new(1));
-        molecule.merge_with(Molecule::new(2));
+        let mut molecule = Molecule::new(Particle::new("H"));
+        molecule.add_particle(Particle::new("O"));
+        molecule.add_particle(Particle::new("H"));
 
         molecule.add_bond(0, 1);
         molecule.add_bond(1, 2);
 
-        let mut atoms = ParticleVec::new();
-        atoms.push(Particle::new("H"));
-        atoms.push(Particle::new("O"));
-        atoms.push(Particle::new("H"));
-
-        molecule_type(&molecule, atoms.as_slice())
+        molecule.molecule_type()
     };
 
     let mut mc = MonteCarlo::new(units::from(500.0, "K").unwrap());

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -27,8 +27,8 @@ fn main() {
     let input = InteractionsInput::new("data/binary.toml").unwrap();
     input.read(&mut system).unwrap();
 
-    // We can read files to get molecule type
-    let co2 = read_molecule("data/CO2.xyz").unwrap().molecule_type();
+    // We can read files to get molecule hash
+    let co2 = read_molecule("data/CO2.xyz").unwrap().hash();
 
     // Or define a new molecule by hand
     let h2o = {
@@ -39,17 +39,17 @@ fn main() {
         molecule.add_bond(0, 1);
         molecule.add_bond(1, 2);
 
-        molecule.molecule_type()
+        molecule.hash()
     };
 
     let mut mc = MonteCarlo::new(units::from(500.0, "K").unwrap());
 
     // Use the molecular types of CO2 and H2O to specify different probabilities
-    mc.add(Box::new(Translate::with_moltype(units::from(0.5, "A").unwrap(), co2)), 1.0);
-    mc.add(Box::new(Rotate::with_moltype(units::from(10.0, "deg").unwrap(), co2)), 1.0);
+    mc.add(Box::new(Translate::new(units::from(0.5, "A").unwrap(), co2)), 1.0);
+    mc.add(Box::new(Rotate::new(units::from(10.0, "deg").unwrap(), co2)), 1.0);
 
-    mc.add(Box::new(Translate::with_moltype(units::from(10.0, "A").unwrap(), h2o)), 2.0);
-    mc.add(Box::new(Rotate::with_moltype(units::from(20.0, "deg").unwrap(), h2o)), 2.0);
+    mc.add(Box::new(Translate::new(units::from(10.0, "A").unwrap(), h2o)), 2.0);
+    mc.add(Box::new(Rotate::new(units::from(20.0, "deg").unwrap(), h2o)), 2.0);
 
     let mut simulation = Simulation::new(Box::new(mc));
     simulation.run(&mut system, 200_000_000);

--- a/examples/mc_npt_ethane.rs
+++ b/examples/mc_npt_ethane.rs
@@ -39,7 +39,7 @@ fn get_system() -> System {
     system.add_bond_potential(("C", "C"), bond);
 
     // Check if bonds are guessed correctly.
-    assert_eq!(system.size(), 2 * system.molecules().len());
+    assert_eq!(system.size(), 2 * system.molecules_count());
     system
 }
 

--- a/examples/mc_npt_ethane.rs
+++ b/examples/mc_npt_ethane.rs
@@ -65,8 +65,8 @@ fn main() {
     // I.e. for a dilute gas, translation amplitudes grow infinitely
     // since the system has so few particles that almost all moves are
     // accepted no matter what the amplitude will be.
-    mc.add_move_with_acceptance(Box::new(Translate::new(delta_trans)), 50.0, 0.5);
-    mc.add_move_with_acceptance(Box::new(Rotate::new(delta_rot)), 50.0, 0.5);
+    mc.add_move_with_acceptance(Box::new(Translate::new(delta_trans, None)), 50.0, 0.5);
+    mc.add_move_with_acceptance(Box::new(Rotate::new(delta_rot, None)), 50.0, 0.5);
     mc.add_move_with_acceptance(Box::new(Resize::new(pressure, delta_vol)), 2.0, 0.5);
     mc.set_amplitude_update_frequency(500);
 

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -81,8 +81,8 @@ fn main() {
     // I.e. for a dilute gas, translation amplitudes grow infinitely
     // since the system has so few particles that almost all moves are
     // accepted no matter what the amplitude will be.
-    mc.add_move_with_acceptance(Box::new(Translate::new(delta_trans)), 45.0, 0.5);
-    mc.add_move_with_acceptance(Box::new(Rotate::new(delta_rot)), 45.0, 0.5);
+    mc.add_move_with_acceptance(Box::new(Translate::new(delta_trans, None)), 45.0, 0.5);
+    mc.add_move_with_acceptance(Box::new(Rotate::new(delta_rot, None)), 45.0, 0.5);
     mc.add_move_with_acceptance(Box::new(Resize::new(pressure, delta_vol)), 2.0, 0.5);
     mc.set_amplitude_update_frequency(500);
 

--- a/examples/mc_npt_spce.rs
+++ b/examples/mc_npt_spce.rs
@@ -55,7 +55,7 @@ fn get_system() -> System {
     system.set_coulomb_potential(Box::new(SharedEwald::new(ewald)));
 
     // Check if bonds are guessed correctly.
-    assert_eq!(system.size(), 3 * system.molecules().len());
+    assert_eq!(system.size(), 3 * system.molecules_count());
     return system;
 }
 

--- a/examples/xenon.rs
+++ b/examples/xenon.rs
@@ -26,7 +26,7 @@ fn main() {
     // Create a Monte Carlo propagator
     let mut mc = MonteCarlo::new(units::from(500.0, "K").unwrap());
     // Add the `Translate` move with 0.5 A amplitude and 1.0 frequency
-    mc.add(Box::new(Translate::new(units::from(0.5, "A").unwrap())), 1.0);
+    mc.add(Box::new(Translate::new(units::from(0.5, "A").unwrap(), None)), 1.0);
     let mut simulation = Simulation::new(Box::new(mc));
 
     let trajectory_out = Box::new(TrajectoryOutput::new("trajectory.xyz").unwrap());

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1"
 thread_local = "0.3"
 caldyn = "0.4"
 itertools = "0.7"
-soa_derive = "0.6"
+soa_derive = "0.7"
 
 [dev-dependencies]
 lumol = {path = "../.."}

--- a/src/core/src/energy/global/ewald.rs
+++ b/src/core/src/energy/global/ewald.rs
@@ -1082,7 +1082,7 @@ mod tests {
         H -0.7 -0.7  0.3
         H  0.3 -0.3 -0.8
         ");
-        assert!(system.molecules().len() == 1);
+        assert!(system.molecules_count() == 1);
 
         for particle in system.particles_mut() {
             if particle.name == "O" {
@@ -1462,7 +1462,7 @@ mod tests {
             H  1.3  1.3  0.3
             H  2.3  1.7 -0.8
             ");
-            assert!(system.molecules().len() == 2);
+            assert!(system.molecules_count() == 2);
 
             for particle in system.particles_mut() {
                 if particle.name == "O" {

--- a/src/core/src/energy/global/wolf.rs
+++ b/src/core/src/energy/global/wolf.rs
@@ -418,7 +418,7 @@ mod tests {
                 H  2.3  1.7 -0.8
                 ",
             );
-            assert!(system.molecules().len() == 2);
+            assert!(system.molecules_count() == 2);
 
             for particle in system.particles_mut() {
                 if particle.name == "O" {

--- a/src/core/src/sim/mc/moves/mod.rs
+++ b/src/core/src/sim/mc/moves/mod.rs
@@ -63,10 +63,14 @@ pub trait MCMove {
 fn select_molecule(system: &System, moltype: Option<u64>, rng: &mut RngCore) -> Option<usize> {
     if let Some(moltype) = moltype {
         // Pick a random molecule with matching moltype
-        let mols = system.molecules_with_moltype(moltype);
+        let mols = system.molecules()
+            .enumerate()
+            .filter(|(_, m)| m.molecule_type() == moltype)
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>();
         return rng.choose(&mols).cloned();
     } else {
-        let nmols = system.molecules().len();
+        let nmols = system.molecules_count();
         if nmols == 0 {
             return None;
         } else {

--- a/src/core/src/sim/mc/moves/mod.rs
+++ b/src/core/src/sim/mc/moves/mod.rs
@@ -10,7 +10,7 @@
 //! In all this module, beta refers to the Boltzmann factor 1/(kB T)
 use rand::{RngCore, Rng};
 
-use sys::{EnergyCache, System};
+use sys::{EnergyCache, System, MoleculeHash};
 
 /// The `MCMove` trait correspond to the set of methods used in Monte Carlo
 /// simulations.
@@ -54,18 +54,18 @@ pub trait MCMove {
 }
 
 /// Select a random molecule in the system using `rng` as random number
-/// generator. If `moltype` is `None`, any molecule can be chosen. If `moltype`
-/// is `Some(molecule_type)`, then a molecule with matching type is selected.
+/// generator. If `hash` is `None`, any molecule can be chosen. If `hash` is
+/// `Some(hash)`, then a molecule with matching hash is selected.
 ///
 /// This function returns `None` if no matching molecule was found, and
 /// `Some(molid)` with `molid` the index of the molecule if a molecule was
 /// selected.
-fn select_molecule(system: &System, moltype: Option<u64>, rng: &mut RngCore) -> Option<usize> {
-    if let Some(moltype) = moltype {
+fn select_molecule(system: &System, hash: Option<MoleculeHash>, rng: &mut RngCore) -> Option<usize> {
+    if let Some(hash) = hash {
         // Pick a random molecule with matching moltype
         let mols = system.molecules()
             .enumerate()
-            .filter(|(_, m)| m.molecule_type() == moltype)
+            .filter(|(_, m)| m.hash() == hash)
             .map(|(i, _)| i)
             .collect::<Vec<_>>();
         return rng.choose(&mols).cloned();

--- a/src/core/src/sim/md/controls.rs
+++ b/src/core/src/sim/md/controls.rs
@@ -196,8 +196,9 @@ impl Rewrap {
 
 impl Control for Rewrap {
     fn control(&mut self, system: &mut System) {
-        for i in 0..system.molecules().len() {
-            system.wrap_molecule(i);
+        let cell = system.cell;
+        for mut molecule in system.molecules_mut() {
+            molecule.wrap(&cell);
         }
     }
 }

--- a/src/core/src/sys/chfl.rs
+++ b/src/core/src/sys/chfl.rs
@@ -476,7 +476,7 @@ mod tests {
 
     use super::*;
     use std::io::prelude::*;
-    use sys::{Angle, Bond};
+    use sys::{Angle, Bond, MoleculeHash};
 
     static WATER: &'static str = "3
 
@@ -538,7 +538,7 @@ END
 
         // This is only a simple regression test on the moltype function. Feel
         // free to change the value if the molecule type algorithm change.
-        assert_eq!(molecule.molecule_type(), 2727145596042757306);
+        assert_eq!(molecule.hash(), MoleculeHash::new(3988311241583852942));
     }
 
     #[test]
@@ -581,6 +581,6 @@ END
 
         // This is only a simple regression test on the moltype function. Feel
         // free to change the value if the molecule type algorithm change.
-        assert_eq!(molecule.molecule_type(), 2028056351119909064);
+        assert_eq!(molecule.hash(), MoleculeHash::new(10634064187773497961));
     }
 }

--- a/src/core/src/sys/compute.rs
+++ b/src/core/src/sys/compute.rs
@@ -359,7 +359,7 @@ mod test {
         assert!(system.add_bond(0, 1).is_empty());
         assert!(system.add_bond(1, 2).is_empty());
         assert!(system.add_bond(2, 3).is_empty());
-        assert_eq!(system.molecules().len(), 1);
+        assert_eq!(system.molecules_count(), 1);
         assert_eq!(system.molecule(0).bonds().len(), 3);
 
         system.add_pair_potential(("F", "F"), PairInteraction::new(Box::new(NullPotential), 0.0));

--- a/src/core/src/sys/config/bonding.rs
+++ b/src/core/src/sys/config/bonding.rs
@@ -1,0 +1,505 @@
+// Lumol, an extensible molecular simulation engine
+// Copyright (C) Lumol's contributors — BSD license
+
+use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::ops::Range;
+
+use sys::{Angle, Bond, BondDistances, Dihedral};
+use types::Array2;
+
+
+/// The basic building block for a topology. A `Bonding` contains data about
+/// the connectivity (bonds, angles, dihedrals) between particles in a single
+/// molecule.
+#[derive(Debug, Clone)]
+pub struct Bonding {
+    /// All the bonds in the molecule.
+    bonds: HashSet<Bond>,
+    /// All the angles in the molecule. Rebuilt as needed from the bond list.
+    angles: HashSet<Angle>,
+    /// All the dihedral angles in the molecule. Rebuilt as needed from the
+    /// bond list.
+    dihedrals: HashSet<Dihedral>,
+    /// Matrix of bond distances in the molecule. The item at index `i, j`
+    /// encode the bond distance between the particles `i + self.first` and
+    /// `j + self.first`
+    distances: Array2<BondDistances>,
+    /// Range of atomic indexes in this molecule.
+    range: Range<usize>,
+    /// Hashed value of the set of bonds in the system
+    hash: u64,
+}
+
+impl Bonding {
+    /// Create a new `Bonding` containing only the atom i
+    pub fn new(i: usize) -> Bonding {
+        Bonding {
+            bonds: HashSet::new(),
+            angles: HashSet::new(),
+            dihedrals: HashSet::new(),
+            distances: Array2::default((1, 1)),
+            range: i..i + 1,
+            hash: 0,
+        }
+    }
+
+    /// Get the number of atoms in the molecule
+    pub fn size(&self) -> usize {
+        self.range.len()
+    }
+
+    /// Get the first atom of this molecule
+    pub fn start(&self) -> usize {
+        self.range.start
+    }
+
+    /// Get the index of the first atom after this molecule
+    pub fn end(&self) -> usize {
+        self.range.end
+    }
+
+    /// Does this molecule contains the particle `i`
+    pub fn contains(&self, i: usize) -> bool {
+        self.range.start <= i && i < self.range.end
+    }
+
+    /// Get the hash of the bonds
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
+    /// Cache the hash of the bonds
+    fn rehash(&mut self) {
+        let mut hasher = DefaultHasher::new();
+        self.range.len().hash(&mut hasher);
+
+        let mut bonds = self.bonds.iter()
+            .map(|bond| Bond::new(bond.i() - self.start(), bond.j() - self.start()))
+            .collect::<Vec<_>>();
+
+        bonds.sort_unstable();
+        for bond in &bonds {
+            bond.i().hash(&mut hasher);
+            bond.j().hash(&mut hasher);
+        }
+        self.hash = hasher.finish();
+    }
+
+    /// Rebuild the full list of angles and dihedral angles from the list of bonds
+    fn rebuild(&mut self) {
+        self.angles.clear();
+        self.dihedrals.clear();
+        for bond1 in &self.bonds {
+            // Find angles
+            for bond2 in &self.bonds {
+                if bond1 == bond2 {
+                    continue;
+                }
+
+                let angle = if bond1.i() == bond2.j() {
+                    Angle::new(bond2.i(), bond2.j(), bond1.j())
+                } else if bond1.j() == bond2.i() {
+                    Angle::new(bond1.i(), bond1.j(), bond2.j())
+                } else if bond1.j() == bond2.j() {
+                    Angle::new(bond1.i(), bond1.j(), bond2.i())
+                } else if bond1.i() == bond2.i() {
+                    Angle::new(bond1.j(), bond1.i(), bond2.j())
+                } else {
+                    // We will not find any dihedral angle from these bonds
+                    continue;
+                };
+                let _ = self.angles.insert(angle);
+
+                // Find dihedral angles
+                for bond3 in &self.bonds {
+                    if bond2 == bond3 {
+                        continue;
+                    }
+
+                    let dihedral = if angle.k() == bond3.i() && angle.j() != bond3.j() {
+                        Dihedral::new(angle.i(), angle.j(), angle.k(), bond3.j())
+                    } else if angle.k() == bond3.j() && angle.j() != bond3.i() {
+                        Dihedral::new(angle.i(), angle.j(), angle.k(), bond3.i())
+                    } else if angle.i() == bond3.j() && angle.j() != bond3.i() {
+                        Dihedral::new(bond3.i(), angle.i(), angle.j(), angle.k())
+                    } else if angle.i() == bond3.i() && angle.j() != bond3.j() {
+                        Dihedral::new(bond3.j(), angle.i(), angle.j(), angle.k())
+                    } else {
+                        // (angle.k == bond3.i || angle.k == bond3.j) is an
+                        // improper dihedral.
+                        continue;
+                    };
+                    let _ = self.dihedrals.insert(dihedral);
+                }
+            }
+        }
+        self.rebuild_connections();
+        self.rehash();
+    }
+
+    /// Recompute the connectivity matrix from the bonds, angles and dihedrals
+    /// in the system.
+    fn rebuild_connections(&mut self) {
+        let n = self.size();
+        self.distances = Array2::default((n, n));
+
+        let first = self.start();
+        let distances = &mut self.distances;
+        let mut add_distance_term = |i, j, term| {
+            let old_distance = distances[(i - first, j - first)];
+            distances[(i - first, j - first)] = old_distance | term;
+        };
+
+        for bond in &self.bonds {
+            add_distance_term(bond.i(), bond.j(), BondDistances::ONE);
+            add_distance_term(bond.j(), bond.i(), BondDistances::ONE);
+        }
+
+        for angle in &self.angles {
+            add_distance_term(angle.i(), angle.k(), BondDistances::TWO);
+            add_distance_term(angle.k(), angle.i(), BondDistances::TWO);
+        }
+
+        for dihedral in &self.dihedrals {
+            add_distance_term(dihedral.i(), dihedral.m(), BondDistances::THREE);
+            add_distance_term(dihedral.m(), dihedral.i(), BondDistances::THREE);
+        }
+    }
+
+    /// Merge this molecule with `other`. The first particle in `other` should
+    /// be the particle just after the last one in `self`.
+    pub fn merge_with(&mut self, other: Bonding) {
+        assert_eq!(self.range.end, other.range.start);
+        self.range.end = other.range.end;
+        for bond in other.bonds() {
+            let _ = self.bonds.insert(*bond);
+        }
+
+        // Get angles and dihedrals from the other molecule, there is no need to
+        // rebuild these.
+        for angle in other.angles() {
+            let _ = self.angles.insert(*angle);
+        }
+
+        for dihedral in other.dihedrals() {
+            let _ = self.dihedrals.insert(*dihedral);
+        }
+
+        self.rebuild_connections();
+        self.rehash();
+    }
+
+    /// Translate all indexes in this molecule by `delta`.
+    pub fn translate_by(&mut self, delta: isize) {
+        if delta < 0 {
+            // We should not create negative indexes
+            assert!((delta.abs() as usize) < self.start());
+        }
+
+        // The wrapping_add are necessary here, and produce the right result,
+        // thanks to integer overflow and the conversion below.
+        let delta = delta as usize;
+        self.range.start = self.range.start.wrapping_add(delta);
+        self.range.end = self.range.end.wrapping_add(delta);
+
+        let mut new_bonds = HashSet::new();
+        for bond in &self.bonds {
+            let _ = new_bonds.insert(
+                Bond::new(bond.i().wrapping_add(delta), bond.j().wrapping_add(delta)),
+            );
+        }
+        self.bonds = new_bonds;
+
+        let mut new_angles = HashSet::new();
+        for angle in &self.angles {
+            let _ = new_angles.insert(Angle::new(
+                angle.i().wrapping_add(delta),
+                angle.j().wrapping_add(delta),
+                angle.k().wrapping_add(delta),
+            ));
+        }
+        self.angles = new_angles;
+
+        let mut new_dihedrals = HashSet::new();
+        for dihedral in &self.dihedrals {
+            let _ = new_dihedrals.insert(Dihedral::new(
+                dihedral.i().wrapping_add(delta),
+                dihedral.j().wrapping_add(delta),
+                dihedral.k().wrapping_add(delta),
+                dihedral.m().wrapping_add(delta),
+            ));
+        }
+        self.dihedrals = new_dihedrals;
+    }
+
+    /// Add a bond between the particles at indexes `i` and `j`. These particles
+    /// are assumed to be in the molecule
+    pub fn add_bond(&mut self, i: usize, j: usize) {
+        assert!(self.contains(i));
+        assert!(self.contains(j));
+        assert_ne!(i, j);
+        let _ = self.bonds.insert(Bond::new(i, j));
+        self.rebuild();
+    }
+
+    /// Removes particle at index `i` and any associated bonds, angle or
+    /// dihedral. This function also update the indexes for the
+    /// bonds/angles/dihedral by remove 1 to all the values `> i`
+    pub fn remove_particle(&mut self, i: usize) {
+        assert!(self.contains(i));
+        // Remove bonds containing the particle `i`
+        let mut new_bonds = HashSet::new();
+        for bond in self.bonds() {
+            if bond.i() == i || bond.j() == i {
+                continue;
+            }
+
+            let (mut bond_i, mut bond_j) = (bond.i(), bond.j());
+            if bond_i > i {
+                bond_i -= 1;
+            }
+            if bond_j > i {
+                bond_j -= 1;
+            }
+
+            let _ = new_bonds.insert(Bond::new(bond_i, bond_j));
+        }
+
+        self.bonds = new_bonds;
+        self.range.end -= 1;
+        self.rebuild();
+    }
+
+    /// Get the internal list of bonds
+    pub fn bonds(&self) -> &HashSet<Bond> {
+        &self.bonds
+    }
+
+    /// Get the internal list of angles
+    pub fn angles(&self) -> &HashSet<Angle> {
+        &self.angles
+    }
+
+    /// Get the internal list of dihedrals
+    pub fn dihedrals(&self) -> &HashSet<Dihedral> {
+        &self.dihedrals
+    }
+
+    /// Get the all the possible bond paths the particles `i` and `j` in this molecule
+    pub fn bond_distances(&self, i: usize, j: usize) -> BondDistances {
+        assert!(self.contains(i) && self.contains(j));
+        return self.distances[(i - self.start(), j - self.start())];
+    }
+
+    /// Get the indexes of the particles in this molecule. All atoms in the
+    /// returned range are inside this molecule.
+    pub fn indexes(&self) -> Range<usize> {
+        self.range.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use sys::{Angle, Bond, BondDistances, Dihedral};
+
+    #[test]
+    fn translate_by() {
+        let mut bonding = Bonding::new(0);
+        for i in 1..4 {
+            bonding.merge_with(Bonding::new(i));
+        }
+        bonding.add_bond(0, 1);
+        bonding.add_bond(1, 2);
+        bonding.add_bond(2, 3);
+
+        assert_eq!(bonding.start(), 0);
+        assert_eq!(bonding.end(), 4);
+        assert!(bonding.bonds().contains(&Bond::new(2, 3)));
+        assert!(bonding.angles().contains(&Angle::new(1, 2, 3)));
+        assert!(bonding.dihedrals().contains(&Dihedral::new(0, 1, 2, 3)));
+
+        bonding.translate_by(5);
+        assert_eq!(bonding.start(), 5);
+        assert_eq!(bonding.end(), 9);
+        assert!(bonding.bonds().contains(&Bond::new(7, 8)));
+        assert!(bonding.angles().contains(&Angle::new(6, 7, 8)));
+        assert!(bonding.dihedrals().contains(&Dihedral::new(5, 6, 7, 8)));
+
+        bonding.translate_by(-3);
+        assert_eq!(bonding.start(), 2);
+        assert_eq!(bonding.end(), 6);
+        assert!(bonding.bonds().contains(&Bond::new(4, 5)));
+        assert!(bonding.angles().contains(&Angle::new(3, 4, 5)));
+        assert!(bonding.dihedrals().contains(&Dihedral::new(2, 3, 4, 5)));
+    }
+
+    #[test]
+    fn bonding() {
+        // Create ethane like this
+        //       H    H               4    5
+        //       |    |               |    |
+        //   H - C -- C - H       3 - 0 -- 1 - 6
+        //       |    |               |    |
+        //       H    H               2    7
+        let mut bonding = Bonding::new(0);
+
+        for i in 1..8 {
+            bonding.merge_with(Bonding::new(i));
+        }
+
+        bonding.add_bond(0, 1);
+        bonding.add_bond(0, 2);
+        bonding.add_bond(0, 3);
+        bonding.add_bond(0, 4);
+        bonding.add_bond(1, 5);
+        bonding.add_bond(1, 6);
+        bonding.add_bond(1, 7);
+
+        assert_eq!(bonding.start(), 0);
+        assert_eq!(bonding.end(), 8);
+
+        assert_eq!(bonding.size(), 8);
+
+        let bonds = vec![
+            Bond::new(0, 1),
+            Bond::new(0, 2),
+            Bond::new(0, 3),
+            Bond::new(0, 4),
+            Bond::new(1, 5),
+            Bond::new(1, 6),
+            Bond::new(1, 7),
+        ];
+
+        assert_eq!(bonding.bonds().len(), bonds.len());
+        for bond in &bonds {
+            assert!(bonding.bonds().contains(bond));
+        }
+
+        let angles = vec![
+            Angle::new(0, 1, 5),
+            Angle::new(0, 1, 6),
+            Angle::new(0, 1, 7),
+            Angle::new(1, 0, 2),
+            Angle::new(1, 0, 3),
+            Angle::new(1, 0, 4),
+            Angle::new(2, 0, 3),
+            Angle::new(3, 0, 4),
+            Angle::new(2, 0, 4),
+            Angle::new(5, 1, 6),
+            Angle::new(6, 1, 7),
+            Angle::new(5, 1, 7),
+        ];
+
+        assert_eq!(bonding.angles().len(), angles.len());
+        for angle in &angles {
+            assert!(bonding.angles().contains(angle));
+        }
+
+        let dihedrals = vec![
+            Dihedral::new(2, 0, 1, 5),
+            Dihedral::new(2, 0, 1, 6),
+            Dihedral::new(2, 0, 1, 7),
+            Dihedral::new(3, 0, 1, 5),
+            Dihedral::new(3, 0, 1, 6),
+            Dihedral::new(3, 0, 1, 7),
+            Dihedral::new(4, 0, 1, 5),
+            Dihedral::new(4, 0, 1, 6),
+            Dihedral::new(4, 0, 1, 7),
+        ];
+
+        assert_eq!(bonding.dihedrals().len(), dihedrals.len());
+        for dihedral in &dihedrals {
+            assert!(bonding.dihedrals().contains(dihedral));
+        }
+
+        assert!(bonding.bond_distances(0, 1).contains(BondDistances::ONE));
+        assert!(bonding.bond_distances(1, 0).contains(BondDistances::ONE));
+
+        assert!(bonding.bond_distances(0, 7).contains(BondDistances::TWO));
+        assert!(bonding.bond_distances(7, 0).contains(BondDistances::TWO));
+
+        assert!(bonding.bond_distances(3, 5).contains(BondDistances::THREE));
+        assert!(bonding.bond_distances(5, 3).contains(BondDistances::THREE));
+
+        bonding.remove_particle(6);
+        assert_eq!(bonding.bonds().len(), 6);
+        assert_eq!(bonding.angles().len(), 9);
+        assert_eq!(bonding.dihedrals().len(), 6);
+    }
+
+    #[test]
+    fn cyclic() {
+        //   0 -- 1
+        //   |    |
+        //   3 -- 2
+        let mut bonding = Bonding::new(0);
+
+        for i in 1..4 {
+            bonding.merge_with(Bonding::new(i));
+        }
+        bonding.add_bond(0, 1);
+        bonding.add_bond(1, 2);
+        bonding.add_bond(2, 3);
+        bonding.add_bond(3, 0);
+
+        assert!(bonding.bond_distances(0, 3).contains(BondDistances::ONE));
+        assert!(bonding.bond_distances(0, 3).contains(BondDistances::THREE));
+
+        assert!(bonding.angles.contains(&Angle::new(0, 3, 2)));
+        assert!(bonding.angles.contains(&Angle::new(0, 1, 2)));
+    }
+
+    #[test]
+    fn remove_particle() {
+        let mut bonding = Bonding::new(0);
+        for i in 1..4 {
+            bonding.merge_with(Bonding::new(i));
+        }
+
+        assert_eq!(bonding.bonds().len(), 0);
+        assert_eq!(bonding.size(), 4);
+
+        bonding.add_bond(0, 1);
+        bonding.add_bond(2, 3);
+        assert_eq!(bonding.bonds().len(), 2);
+        assert_eq!(bonding.size(), 4);
+
+        bonding.remove_particle(1);
+        assert_eq!(bonding.bonds().len(), 1);
+        assert_eq!(bonding.size(), 3);
+
+        bonding.merge_with(Bonding::new(3));
+        assert_eq!(bonding.bonds().len(), 1);
+        assert_eq!(bonding.size(), 4);
+    }
+
+    #[test]
+    fn hash() {
+        let mut bonding = Bonding::new(0);
+        assert_eq!(bonding.hash, 0);
+
+        for i in 1..4 {
+            bonding.merge_with(Bonding::new(i));
+        }
+
+        let hash = bonding.hash;
+        assert!(hash != 0);
+
+        bonding.add_bond(0, 1);
+        bonding.add_bond(2, 3);
+        assert!(bonding.hash != hash);
+        let hash = bonding.hash;
+
+        bonding.remove_particle(1);
+        assert!(bonding.hash != hash);
+        let hash = bonding.hash;
+
+        // Hash should be the same when translating the bonds
+        bonding.translate_by(67);
+        bonding.rehash();
+        assert_eq!(bonding.hash, hash);
+    }
+}

--- a/src/core/src/sys/config/configuration.rs
+++ b/src/core/src/sys/config/configuration.rs
@@ -645,7 +645,7 @@ mod tests {
     }
 
     #[test]
-    fn molecule_type() {
+    fn hash() {
         let mut configuration = Configuration::new();
         // One helium
         configuration.add_particle(particle("He"));
@@ -672,18 +672,18 @@ mod tests {
         assert_eq!(configuration.molecules_count(), 5);
         // The helium particles
         assert_eq!(
-            configuration.molecule(0).molecule_type(),
-            configuration.molecule(3).molecule_type()
+            configuration.molecule(0).hash(),
+            configuration.molecule(3).hash()
         );
 
         // The water molecules
         assert_eq!(
-            configuration.molecule(1).molecule_type(),
-            configuration.molecule(2).molecule_type()
+            configuration.molecule(1).hash(),
+            configuration.molecule(2).hash()
         );
         assert_ne!(
-            configuration.molecule(1).molecule_type(),
-            configuration.molecule(4).molecule_type()
+            configuration.molecule(1).hash(),
+            configuration.molecule(4).hash()
         );
     }
 }

--- a/src/core/src/sys/config/mod.rs
+++ b/src/core/src/sys/config/mod.rs
@@ -9,6 +9,7 @@ pub use self::periodic::{ElementData, PeriodicTable};
 mod particles;
 pub use self::particles::{Particle, ParticleKind};
 pub use self::particles::{ParticleRef, ParticleRefMut};
+pub use self::particles::{ParticlePtr, ParticlePtrMut};
 pub use self::particles::{ParticleSlice, ParticleSliceMut, ParticleVec};
 
 mod composition;
@@ -21,9 +22,11 @@ mod connect;
 pub use self::connect::{Angle, Bond, Dihedral};
 pub use self::connect::BondDistances;
 
+mod bonding;
+pub use self::bonding::Bonding;
+
 mod molecules;
-pub use self::molecules::Molecule;
-pub use self::molecules::molecule_type;
+pub use self::molecules::{Molecule, MoleculeRef, MoleculeRefMut};
 
 mod configuration;
 pub use self::configuration::Configuration;

--- a/src/core/src/sys/config/mod.rs
+++ b/src/core/src/sys/config/mod.rs
@@ -26,7 +26,7 @@ mod bonding;
 pub use self::bonding::Bonding;
 
 mod molecules;
-pub use self::molecules::{Molecule, MoleculeRef, MoleculeRefMut};
+pub use self::molecules::{Molecule, MoleculeRef, MoleculeRefMut, MoleculeHash};
 
 mod configuration;
 pub use self::configuration::Configuration;

--- a/src/core/src/sys/config/molecules.rs
+++ b/src/core/src/sys/config/molecules.rs
@@ -9,6 +9,19 @@ use sys::{Particle, ParticleVec, ParticleSlice, ParticleSliceMut};
 use sys::{Bonding, UnitCell};
 use types::{Vector3D, Zero};
 
+/// A molecule hash allow to identify a molecule from its atoms and bonds, and
+/// to know wether two molecules are the same without checking each atom and
+/// bond.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MoleculeHash(u64);
+
+#[cfg(test)]
+impl MoleculeHash {
+    pub(crate) fn new(value: u64) -> MoleculeHash {
+        MoleculeHash(value)
+    }
+}
+
 /// A Molecule associate some particles bonded together.
 ///
 /// [`Molecule`] implement `Deref` to a [`Bonding`] struct, to give read access
@@ -248,13 +261,13 @@ impl_on!(Molecule, MoleculeRef<'a>, MoleculeRefMut<'a>, => {
     /// order), and the set of bonds in the molecule. This means that two
     /// molecules will have the same type if and only if they contains the same
     /// atoms and the same bonds, **in the same order**.
-    pub fn molecule_type(&self) -> u64 {
+    pub fn hash(&self) -> MoleculeHash {
         let mut hasher = DefaultHasher::new();
-        self.bonding.hash().hash(&mut hasher);
+        self.bonding.hash(&mut hasher);
         for name in self.particles().name {
             name.hash(&mut hasher);
         }
-        hasher.finish()
+        MoleculeHash(hasher.finish())
     }
 });
 

--- a/src/core/src/sys/system.rs
+++ b/src/core/src/sys/system.rs
@@ -417,14 +417,14 @@ mod tests {
         system.add_particle(Particle::new("H"));
         system.add_particle(Particle::new("O"));
         system.add_particle(Particle::new("H"));
-        assert_eq!(system.molecules().len(), 3);
+        assert_eq!(system.molecules_count(), 3);
 
         // This uses deref_mut
         let _ = system.add_bond(0, 1);
         let _ = system.add_bond(2, 1);
 
         // This uses deref
-        assert_eq!(system.molecules().len(), 1);
+        assert_eq!(system.molecules_count(), 1);
     }
 
     #[test]

--- a/src/core/src/utils/xyz.rs
+++ b/src/core/src/utils/xyz.rs
@@ -76,7 +76,7 @@ mod tests {
         assert_eq!(system.particles().position[1], Vector3D::new(0.0, 0.0, 0.0));
         assert_eq!(system.particles().position[2], Vector3D::new(0.0, 0.0, 1.5));
 
-        assert_eq!(system.molecules().len(), 1);
+        assert_eq!(system.molecules_count(), 1);
         assert_eq!(system.molecule(0).bonds().len(), 2);
     }
 
@@ -91,7 +91,7 @@ mod tests {
             He 0 0 1",
         );
         assert_eq!(system.size(), 4);
-        assert_eq!(system.molecules().len(), 4);
+        assert_eq!(system.molecules_count(), 4);
         assert_eq!(system.cell, UnitCell::cubic(67.0));
 
         assert_eq!(system.particles().position[0], Vector3D::new(0.0, 0.0, 0.0));
@@ -112,7 +112,7 @@ mod tests {
             ",
         );
         assert_eq!(system.size(), 4);
-        assert_eq!(system.molecules().len(), 4);
+        assert_eq!(system.molecules_count(), 4);
         assert_eq!(system.cell, UnitCell::cubic(67.0));
 
         assert_eq!(system.particles().position[0], Vector3D::new(0.0, 0.0, 0.0));

--- a/src/input/src/simulations/mc.rs
+++ b/src/input/src/simulations/mc.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use toml::value::Table;
 
 use lumol::sim::mc::*;
-use lumol::sys::{molecule_type, read_molecule};
+use lumol::sys::read_molecule;
 use lumol::units;
 
 use FromTomlWithData;
@@ -82,8 +82,7 @@ impl FromTomlWithData for Translate {
         if config.get("molecule").is_some() {
             let molfile = extract::str("molecule", config, "Translate move")?;
             let molfile = get_input_path(root, molfile);
-            let (molecule, atoms) = read_molecule(molfile)?;
-            let moltype = molecule_type(&molecule, atoms.as_slice());
+            let moltype = read_molecule(molfile)?.as_ref().molecule_type();
             Ok(Translate::with_moltype(delta, moltype))
         } else {
             Ok(Translate::new(delta))
@@ -100,8 +99,7 @@ impl FromTomlWithData for Rotate {
         if config.get("molecule").is_some() {
             let molfile = extract::str("molecule", config, "Rotate move")?;
             let molfile = get_input_path(root, molfile);
-            let (molecule, atoms) = read_molecule(molfile)?;
-            let moltype = molecule_type(&molecule, atoms.as_slice());
+            let moltype = read_molecule(molfile)?.as_ref().molecule_type();
             Ok(Rotate::with_moltype(delta, moltype))
         } else {
             Ok(Rotate::new(delta))

--- a/src/input/src/simulations/mc.rs
+++ b/src/input/src/simulations/mc.rs
@@ -82,10 +82,10 @@ impl FromTomlWithData for Translate {
         if config.get("molecule").is_some() {
             let molfile = extract::str("molecule", config, "Translate move")?;
             let molfile = get_input_path(root, molfile);
-            let moltype = read_molecule(molfile)?.as_ref().molecule_type();
-            Ok(Translate::with_moltype(delta, moltype))
+            let hash = read_molecule(molfile)?.as_ref().hash();
+            Ok(Translate::new(delta, hash))
         } else {
-            Ok(Translate::new(delta))
+            Ok(Translate::new(delta, None))
         }
     }
 }
@@ -99,10 +99,10 @@ impl FromTomlWithData for Rotate {
         if config.get("molecule").is_some() {
             let molfile = extract::str("molecule", config, "Rotate move")?;
             let molfile = get_input_path(root, molfile);
-            let moltype = read_molecule(molfile)?.as_ref().molecule_type();
-            Ok(Rotate::with_moltype(delta, moltype))
+            let hash = read_molecule(molfile)?.as_ref().hash();
+            Ok(Rotate::new(delta, hash))
         } else {
-            Ok(Rotate::new(delta))
+            Ok(Rotate::new(delta, None))
         }
     }
 }

--- a/tests/md-butane.rs
+++ b/tests/md-butane.rs
@@ -21,7 +21,7 @@ fn bonds_detection() {
                                  .join("md-butane")
                                  .join("nve.toml");
     let system = Input::new(path).unwrap().read_system().unwrap();
-    assert_eq!(system.molecules().len(), 50);
+    assert_eq!(system.molecules_count(), 50);
 
     for molecule in system.molecules() {
         assert_eq!(molecule.bonds().len(), 3);

--- a/tests/md-methane.rs
+++ b/tests/md-methane.rs
@@ -21,7 +21,7 @@ fn bonds_detection() {
                                  .join("md-methane")
                                  .join("nve.toml");
     let system = Input::new(path).unwrap().read_system().unwrap();
-    assert_eq!(system.molecules().len(), 150);
+    assert_eq!(system.molecules_count(), 150);
 
     for molecule in system.molecules() {
         assert_eq!(molecule.bonds().len(), 4);


### PR DESCRIPTION
This implement the end of #18, specifically the strategy in https://github.com/lumol-org/lumol/issues/18#issuecomment-268860305.

The idea is to have a real `Molecule` type, containing both bonding informations and particles. This means that functions needing particle information (center_of_mass, wrap, ...) can be implemented directly on the Molecule type.

Because the particles are stored in a SoA fashion inside the system, this also adds the `MoleculeRef` and `MoleculeRefMut` types, which are analogues to `&Molecule` and `&mut Molecule`, with data pointing inside a System.